### PR TITLE
Cleaner slug generation through conventions

### DIFF
--- a/src/components/common.js
+++ b/src/components/common.js
@@ -368,7 +368,8 @@ export default {
       }
     },
     entity(to, from) {
-      if (!isEqual(to, from)) {
+      console.log("entity:", from, to);
+      if (!isEqual(to, from) && to != null) {
         this._validate(to);
 
         this.initialize();


### PR DESCRIPTION
Conventions:

1. all catalogs are named `catalog.json`
2. all collections are named `collection.json`
3. catalogs are always distinct from collections
4. all items are named `<id>.json`
5. catalogs/collections are nested 1 level beneath their parent

Unfortunately, these conventions fail to hold IRL. This is particularly problematic because there's no other way to determine what the source filename is (or path, in some cases).

CBERS is a very consistent catalog, but its collections (MUX, AWFI, PAN10M, PAN5M) double as 2nd-level catalogs (3).

The root sample Planet catalog doubles as a collection (3).

The Landsat catalog mostly works, although items are 2 levels deep and named as `<timestamp>/<id>.json` (4) and the timestamp throws things off.

In other words, this approach doesn't work without some retooling of published catalogs (and I'm not clear that there's a path to doing this right, given the ambiguity of resolving filenames).

/cc @cholmes 