### PR TITLE
Usually the item title is nicer than the id

### DIFF
--- a/src/components/Catalog.vue
+++ b/src/components/Catalog.vue
@@ -444,8 +444,8 @@ export default {
               to: `/item${this.path}/${this.slugify(itemUrl)}`,
               title:
                 item.properties.title ||
-                item.id ||
                 itemLink.title ||
+                item.id ||
                 itemLink.href,
               dateAcquired: item.properties.datetime
             };


### PR DESCRIPTION
I think the link title is usually better readable by humans than the item ID.
Thus preferring the link title in the list of options.