### PR TITLE
Fix path matching in router #37

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -128,20 +128,20 @@ const main = async () => {
 
   const routes = [
     {
-      path: "/item/:path*",
+      path: "/item/(.*)",
       component: Item,
       props: route => {
         let ancestors = [CATALOG_URL];
 
-        if (route.params.path != null) {
+        if (route.params.pathMatch) {
           ancestors = ancestors.concat(
-            route.params.path.split("/").map(decode)
+            route.params.pathMatch.split("/").map(decode)
           );
         }
 
         let center = null;
 
-        if (route.hash != "") {
+        if (route.hash) {
           center = route.hash.slice(1).split("/");
         }
 
@@ -157,14 +157,14 @@ const main = async () => {
       }
     },
     {
-      path: "/collection/:path*",
+      path: "/collection/(.*)",
       component: Catalog,
       props: route => {
         let ancestors = [CATALOG_URL];
 
-        if (route.params.path != null) {
+        if (route.params.pathMatch) {
           ancestors = ancestors.concat(
-            route.params.path.split("/").map(decode)
+            route.params.pathMatch.split("/").map(decode)
           );
         }
 
@@ -179,14 +179,14 @@ const main = async () => {
       }
     },
     {
-      path: "/:path*",
+      path: "/(.*)",
       component: Catalog,
       props: route => {
         let ancestors = [CATALOG_URL];
 
-        if (route.params.path != null) {
+        if (route.params.pathMatch) {
           ancestors = ancestors.concat(
-            route.params.path.split("/").map(decode)
+            route.params.pathMatch.split("/").map(decode)
           );
         }
 
@@ -293,9 +293,9 @@ const main = async () => {
       return next(persistedState.path);
     }
 
-    if (to.params.path != null) {
+    if (to.params.pathMatch != null) {
       // pre-load all known entities
-      const urls = to.params.path
+      const urls = to.params.pathMatch
         .split("/")
         .reverse()
         .map(decode);


### PR DESCRIPTION
Fixes #37

Haven't done very intensive testing, but it seems to work for CBERS and the catalog mentioned in the issue. Instead of a named parameter, which seems to fail for // in paths, I just do a unnamed (.*) match, which is a bit broader and accepts // in the path.