### PR TITLE
Loading indicator + show error messages

### DIFF
--- a/src/components/Catalog.vue
+++ b/src/components/Catalog.vue
@@ -2,7 +2,7 @@
   <div>
     <b-alert v-if="errored" variant="danger" show>
       <p>{{ _entity.message }}</p>
-      <p>Please not that some servers don't allow external access via web browsers (no CORS headers).</p>
+      <p>Please note that some servers don't allow external access via web browsers (e.g., when CORS headers are not present).</p>
       <p><a href="#" @click="$router.go(-1)">Go back</a></p>
     </b-alert>
     <b-spinner v-else-if="!loaded" label="Loading..."></b-spinner>

--- a/src/components/Catalog.vue
+++ b/src/components/Catalog.vue
@@ -1,6 +1,12 @@
 <template>
   <div>
-    <b-container :class="loaded && 'loaded'">
+    <b-alert v-if="errored" variant="danger" show>
+      <p>{{ _entity.message }}</p>
+      <p>Please not that some servers don't allow external access via web browsers (no CORS headers).</p>
+      <p><a href="#" @click="$router.go(-1)">Go back</a></p>
+    </b-alert>
+    <b-spinner v-else-if="!loaded" label="Loading..."></b-spinner>
+    <b-container v-else :class="loaded && 'loaded'">
       <b-row>
         <b-col md="12">
           <header>

--- a/src/components/Item.vue
+++ b/src/components/Item.vue
@@ -1,6 +1,8 @@
 <template>
   <div>
-    <b-container :class="loaded && 'loaded'">
+    <b-alert v-if="errored" variant="danger" show>{{ _entity.message }}</b-alert>
+    <b-spinner v-else-if="!loaded" label="Loading..."></b-spinner>
+    <b-container v-else :class="loaded && 'loaded'">
       <b-row>
         <b-col md="12">
           <header>

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -65,14 +65,7 @@ export default {
       return (this.collection && this.collection.properties) || {};
     },
     _entity() {
-      const entity = this.getEntity(this.url);
-
-      if (entity instanceof Error) {
-        this.$router.replace("/");
-        return;
-      }
-
-      return entity;
+      return this.getEntity(this.url);
     },
     _keywords() {
       // [].concat() is a work-around for catalogs where keywords is a string (SpaceNet)
@@ -141,8 +134,14 @@ export default {
         MARKDOWN_WRITER.render(MARKDOWN_READER.parse(this._description))
       );
     },
+    errored() {
+      return (this._entity instanceof Error);
+    },
     entity() {
-      return this._entity;
+      if (this.errored) {
+        return {};
+      }
+      return this._entity || {};
     },
     id() {
       // REQUIRED
@@ -186,7 +185,7 @@ export default {
       return this.entity.links || [];
     },
     loaded() {
-      return this.entity != null;
+      return Object.keys(this.entity).length > 0;
     },
     propertyList() {
       const skip = key => propertyMap[key] && propertyMap[key].skip;


### PR DESCRIPTION
This might be a bit controversial, but I added two things that seemed to be a bit nicer when integrating with STAC Index:

1. Show a loading indicator until the page is loaded
2. Show an error message if the underlying main request to the data source failed. Until now it just redirected to the / path without any notice. I think this solution is cleaner. I added a note regarding CORS, but can also remove it. That seems to be the most common error so thought it's good to mention.