### PR TITLE
Add missing space for item license

### DIFF
--- a/src/components/Item.vue
+++ b/src/components/Item.vue
@@ -148,8 +148,7 @@
                     <td>
                       <!-- eslint-disable-next-line vue/no-v-html -->
                       <span v-html="license"></span>
-                      <template v-if="licensor"
-                        >by
+                      <template v-if="licensor"> by
                         <!-- eslint-disable-next-line vue/no-v-html -->
                         <span v-html="licensor"></span>
                       </template>


### PR DESCRIPTION
Looked like this before:

![grafik](https://user-images.githubusercontent.com/8262166/92416502-1fbe3380-f15e-11ea-8df2-7b94e203bce1.png)
