### PR TITLE
Allow the tileserver to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,46 @@ cause problems on certain web hosts. To use _hash mode_, set
 `HISTORY_MODE=hash` when running or building. This will be compatible with
 S3, stock Apache, etc.
 
+## Other options
+
+### STAC_PROXY_URL
+
+Setting the `STAC_PROXY_URL` allows users to modify the URLs contained in the catalog to point to another location.
+For instance, if you are serving a catalog on the local file system at `/home/user/catalog.json`, but want to serve
+the data out from a server located at `http://localhost:8888/`, you can use:
+
+```
+CATALOG_URL=http://localhost:8888/catalog.json STAC_PROXY_URL="/home/user|http://localhost:8888" npm start -- --open
+```
+
+Notice the format of the value: it is the original location and the proxy location separated by the `|` character, i.e. `{original}|{proxy}`.
+
+In this example, any href contained in the STAC (including link or asset hrefs) will replace any occurrence of `/home/user/` with `http://localhost:8888`.
+
+This can also be helpful when proxying a STAC that does not have cors enabled; by using STAC_PROXY_URL you can proxy the original STAC server with one that enables cors
+and be able to browse that catalog.
+
+### TILE_SOURCE_TEMPLATE
+
+The `TILE_SOURCE_TEMPLATE` environment variable controls the tile layer that is used to render COGs. If not set, the default value is:
+
+```
+https://tiles.rdnt.io/tiles/{z}/{x}/{y}@2x?url={ASSET_HREF}
+```
+
+which uses the [tiles.rdnt.io](https://github.com/radiantearth/tiles.rdnt.io) project to serve publicly accessible COGs as tile layers.
+
+The format of this value is a tile layer template with an optional `{ASSET_HREF}` that will be replaced with the COG asset href. For example,
+using a local version of [titiler](https://github.com/developmentseed/titiler) to serve local COG files would look something like:
+
+```
+TILE_SOURCE_TEMPLATE=http://localhost:8000/cog/tiles/{z}/{x}/{y}?url={ASSET_HREF} npm start -- --open
+```
+
+### TILE_PROXY_URL
+
+`TILE_PROXY_URL` is very similar to STAC_PROXY_URL, but is only used for asset hrefs passed into the TILE_SOURCE_TEMPLATE. This enables deployment scenarios where the tiler needs to reference a proxy server by a different name, e.g. in a docker-compose setup with linked containers.
+
 ## Building
 
 ```bash

--- a/src/components/Item.vue
+++ b/src/components/Item.vue
@@ -138,10 +138,11 @@ import "leaflet-easybutton";
 import { mapActions, mapGetters } from "vuex";
 
 import common from "./common";
-import { transformItem } from "../migrate"
+import { getTileSource } from "../util";
+import { transformItem } from "../migrate";
 
-import AssetTab from './AssetTab.vue'
-import MetadataSidebar from './MetadataSidebar.vue'
+import AssetTab from './AssetTab.vue';
+import MetadataSidebar from './MetadataSidebar.vue';
 
 const COG_TYPES = [
   "image/vnd.stac.geotiff; cloud-optimized=true",
@@ -446,13 +447,7 @@ export default {
         return "";
       }
 
-      // TODO global config
-      return `https://tiles.rdnt.io/tiles/{z}/{x}/{y}@2x?url=${encodeURIComponent(
-        this.selectedImage.href
-      )}`;
-      // return `http://localhost:8000/tiles/{z}/{x}/{y}@2x?url=${encodeURIComponent(
-      //   this.cog
-      // )}`;
+      return getTileSource(this.selectedImage.href);
     },
     visibleTabs() {
       return [

--- a/src/config.js
+++ b/src/config.js
@@ -1,7 +1,17 @@
 export const CATALOG_URL =
   process.env.CATALOG_URL ||
-      "https://raw.githubusercontent.com/cholmes/sample-stac/master/stac/catalog.json";
+  "https://raw.githubusercontent.com/cholmes/sample-stac/master/stac/catalog.json";
 
 export const STAC_VERSION =
   process.env.STAC_VERSION ||
-      "0.9.0";
+  "0.9.0";
+
+export const TILE_SOURCE_TEMPLATE =
+  process.env.TILE_SOURCE_TEMPLATE ||
+  "https://tiles.rdnt.io/tiles/{z}/{x}/{y}@2x?url={ASSET_HREF}";
+
+export const STAC_PROXY_URL =
+  process.env.STAC_PROXY_URL;
+
+export const TILE_PROXY_URL =
+  process.env.TILE_PROXY_URL

--- a/src/main.js
+++ b/src/main.js
@@ -19,8 +19,8 @@ import "bootstrap-vue/dist/bootstrap-vue.css";
 import "leaflet/dist/leaflet.css";
 import "vue-multiselect/dist/vue-multiselect.min.css";
 
-import {CATALOG_URL, STAC_VERSION } from './config';
-import { fetchUri, fetchSchemaValidator } from "./util";
+import { CATALOG_URL, STAC_VERSION } from './config';
+import { fetchUri, fetchSchemaValidator, getProxiedUri } from "./util";
 import Catalog from "./components/Catalog.vue";
 import Item from "./components/Item.vue";
 
@@ -59,9 +59,10 @@ const slugify = uri => bs58.encode(Buffer.from(makeRelative(uri)));
 
 const resolve = (href, base = CATALOG_URL) => {
   // Encode colons from all but schema, as they create errors in URL resolving.
+  const proxiedUri = getProxiedUri(href);
   const hrefEncoded =
-        href.replace(':', encodeURIComponent(':'))
-            .replace(encodeURIComponent(':') + '//', '://');
+    proxiedUri.replace(':', encodeURIComponent(':'))
+      .replace(encodeURIComponent(':') + '//', '://');
   return new URL(hrefEncoded, base).toString();
 };
 
@@ -287,7 +288,7 @@ const main = async () => {
       persistedState.path != null &&
       persistedState.path !== to.path.replace(/\/$/, "") &&
       persistedState.path.toLowerCase() ===
-        to.path.toLowerCase().replace(/\/$/, "")
+      to.path.toLowerCase().replace(/\/$/, "")
     ) {
       return next(persistedState.path);
     }

--- a/src/util.js
+++ b/src/util.js
@@ -1,21 +1,24 @@
 import Ajv from "ajv";
 
-const STAC_PROXY_URL =
-  process.env.STAC_PROXY_URL;
+import { TILE_SOURCE_TEMPLATE, STAC_PROXY_URL, TILE_PROXY_URL } from './config';
 
-export async function fetchUri(uri) {
+export const getProxiedUri = (uri) => {
   // If we are proxying a STAC Catalog, replace any URI with the proxied address.
   // STAC_PROXY_URL has the form https://thingtoproxy.com|http://proxy:111
-  const proxiedUri = !!STAC_PROXY_URL ? (
+  return !!STAC_PROXY_URL ? (
     uri.replace(STAC_PROXY_URL.split('|')[0], STAC_PROXY_URL.split('|')[1])
   ) : uri;
+}
+
+export async function fetchUri(uri) {
+  const proxiedUri = getProxiedUri(uri);
   return fetch(proxiedUri);
 };
 
-const modifyLoadSchemaUri = function(baseUrl, uri) {
-  if(uri.includes("://")) { return uri; } // Absolute URI
+const modifyLoadSchemaUri = function (baseUrl, uri) {
+  if (uri.includes("://")) { return uri; } // Absolute URI
 
-  if(uri.includes("/")) {
+  if (uri.includes("/")) {
     // Relative path, e.g. collection to catalog.
     return `${baseUrl}/${uri}`;
   }
@@ -24,13 +27,13 @@ const modifyLoadSchemaUri = function(baseUrl, uri) {
   return `${baseUrl}/item-spec/json-schema/${uri}`;
 };
 
-const fixUpSchema = function(schema, schemaUri) {
+const fixUpSchema = function (schema, schemaUri) {
   // Make $id unique, otherwise AjV will complain
   // Taken from https://github.com/m-mohr/stac-node-validator/blob/master/index.js#L118 (79d3461)
   schema.$id = schemaUri + '#';
 
   // Fix old schemas that have 'id' instead of '$id'
-  if("id" in schema) {
+  if ("id" in schema) {
     delete schema.id;
   }
 
@@ -43,11 +46,11 @@ export async function fetchSchemaValidator(stacObjectType, stacVersion) {
   let baseUrl = stacVersion === '1.0.0-beta.1' ? (
     `https://raw.githubusercontent.com/radiantearth/stac-spec/dev`
   ) : (
-    `https://raw.githubusercontent.com/radiantearth/stac-spec/v${stacVersion}`
-  );
+      `https://raw.githubusercontent.com/radiantearth/stac-spec/v${stacVersion}`
+    );
 
-  let schemaUrl = ( `${baseUrl}/${stacObjectType}-spec` +
-                   `/json-schema/${stacObjectType}.json`);
+  let schemaUrl = (`${baseUrl}/${stacObjectType}-spec` +
+    `/json-schema/${stacObjectType}.json`);
 
   const rsp = await fetchUri(schemaUrl);
   if (!rsp.ok) {
@@ -56,12 +59,12 @@ export async function fetchSchemaValidator(stacObjectType, stacVersion) {
 
   const schema = fixUpSchema(await rsp.json(), schemaUrl);
 
-  const loadSchema = async function(uri) {
+  const loadSchema = async function (uri) {
     let uriToFetch = modifyLoadSchemaUri(baseUrl, uri);
 
     // Fetching the $schema from json-schema.org was causing a recursive loop;
     // avoid fetching.
-    if(uriToFetch.includes("http://json-schema.org/")) {
+    if (uriToFetch.includes("http://json-schema.org/")) {
       return {};
     };
 
@@ -83,3 +86,17 @@ export async function fetchSchemaValidator(stacObjectType, stacVersion) {
 
   return ajv.compileAsync(schema);
 };
+
+const getTileProxiedUri = (uri) => {
+  // Tile sources can be proxied differently than other assets, replace any asset HREF with the proxied address.
+  // Note: This will occur after the STAC_PROXY_URL is used.
+  // TILE_PROXY_URL has the form https://thingtoproxy.com|http://proxy:111
+  return !!TILE_PROXY_URL ? (
+    uri.replace(TILE_PROXY_URL.split('|')[0], TILE_PROXY_URL.split('|')[1])
+  ) : uri;
+}
+
+export const getTileSource = (assetHref) => {
+  const proxiedUri = getTileProxiedUri(assetHref);
+  return TILE_SOURCE_TEMPLATE.replace("{ASSET_HREF}", proxiedUri);
+}


### PR DESCRIPTION
This PR adds the ability to set an environment variable when building or running stac-browser that determines the tile layer source URL for serving out COG tiles on item pages. Prior to this, stac-browser could only use tiles.rdnt.io to serve COGs. This works great for publicly accessible COGs exposed on the internet, but is unable to serve COGs in more complicated scenarios - e.g. from the local filesystem on a locally deployed stac-browser.

This also introduces a parameter for proxying the tile source differently than the other elements of the STAC. `STAC_PROXY_URL` can be used for example to serve local files through a local server, or to proxy a server that doesn't not have CORS enabled with one that does. The `TILE_PROXY_URL` URL enables a scenario where the tile service proxy needs to be different in that scenario - specifically, in a docker-compose environment where one container (the tile server) must reference another container (serving data) by a specific name and not through `localhost`.

These changes do not change the behavior of STAC_BROWSER when none of these values are set.