### PR TITLE
Add tab for Zarr metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4737,6 +4737,21 @@
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
     },
+    "axios": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
+      "integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      },
+      "dependencies": {
+        "follow-redirects": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
+          "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA=="
+        }
+      }
+    },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4737,21 +4737,6 @@
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
     },
-    "axios": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
-      "integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
-      "requires": {
-        "follow-redirects": "^1.10.0"
-      },
-      "dependencies": {
-        "follow-redirects": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
-          "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA=="
-        }
-      }
-    },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   "dependencies": {
     "@babel/polyfill": "^7.6.0",
     "ajv": "^6.10.2",
-    "axios": "^0.20.0",
     "bootstrap-vue": "^2.0.2",
     "bs58": "^4.0.1",
     "clone": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@babel/polyfill": "^7.6.0",
     "ajv": "^6.10.2",
+    "axios": "^0.20.0",
     "bootstrap-vue": "^2.0.2",
     "bs58": "^4.0.1",
     "clone": "^2.1.2",

--- a/src/components/Catalog.vue
+++ b/src/components/Catalog.vue
@@ -177,7 +177,6 @@ import { mapActions, mapGetters } from "vuex";
 
 import common from "./common";
 import AssetTab from './AssetTab.vue'
-import ZarrMetadataTab from "./ZarrMetadataTab.vue";
 import MetadataSidebar from './MetadataSidebar.vue'
 
 import { transformCatalog } from "../migrate"

--- a/src/components/Catalog.vue
+++ b/src/components/Catalog.vue
@@ -132,6 +132,11 @@
               :hasBands="hasBands"
               :active="false"
             ></AssetTab>
+            <ZarrMetadataTab
+              v-if="visibleTabs.includes('zarrMetadata')"
+              :active="false"
+              :zarr-metadata-url="zarrMetadataUrl"
+            ></ZarrMetadataTab>
           </b-tabs>
         </b-col>
         <b-col
@@ -172,6 +177,7 @@ import { mapActions, mapGetters } from "vuex";
 
 import common from "./common";
 import AssetTab from './AssetTab.vue'
+import ZarrMetadataTab from "./ZarrMetadataTab.vue";
 import MetadataSidebar from './MetadataSidebar.vue'
 
 import { transformCatalog } from "../migrate"
@@ -207,7 +213,7 @@ export default {
       required: true
     }
   },
-  components: { AssetTab, MetadataSidebar },
+  components: { AssetTab, ZarrMetadataTab, MetadataSidebar },
   data() {
     return {
       externalItemCount: 0,
@@ -610,7 +616,8 @@ export default {
         (this.hasExternalItems || this.itemCount > 0) && "items",
         this.bands.length > 0 && "bands",
         this.summaries && "summaries",
-        this.assets && this.assets.length > 0 && "assets"
+        this.assets && this.assets.length > 0 && "assets",
+        this.zarrMetadataUrl && "zarrMetadata"
       ].filter(x => x != null && x !== false);
     }
   },

--- a/src/components/Catalog.vue
+++ b/src/components/Catalog.vue
@@ -213,7 +213,11 @@ export default {
       required: true
     }
   },
-  components: { AssetTab, ZarrMetadataTab, MetadataSidebar },
+  components: {
+    AssetTab,
+    ZarrMetadataTab: () => import('./ZarrMetadataTab.vue'),
+    MetadataSidebar
+  },
   data() {
     return {
       externalItemCount: 0,

--- a/src/components/Catalog.vue
+++ b/src/components/Catalog.vue
@@ -125,6 +125,11 @@
                 striped
               />
             </b-tab>
+            <ZarrMetadataTab
+              v-if="visibleTabs.includes('zarrMetadata')"
+              :active="true"
+              :zarr-metadata-url="zarrMetadataUrl"
+            ></ZarrMetadataTab>
             <AssetTab
               v-if="visibleTabs.includes('assets')"
               :assets="assets"
@@ -132,11 +137,6 @@
               :hasBands="hasBands"
               :active="false"
             ></AssetTab>
-            <ZarrMetadataTab
-              v-if="visibleTabs.includes('zarrMetadata')"
-              :active="false"
-              :zarr-metadata-url="zarrMetadataUrl"
-            ></ZarrMetadataTab>
           </b-tabs>
         </b-col>
         <b-col

--- a/src/components/Catalog.vue
+++ b/src/components/Catalog.vue
@@ -127,7 +127,7 @@
             </b-tab>
             <ZarrMetadataTab
               v-if="visibleTabs.includes('zarrMetadata')"
-              :active="true"
+              :active="false"
               :zarr-metadata-url="zarrMetadataUrl"
             ></ZarrMetadataTab>
             <AssetTab

--- a/src/components/ZarrGroup.vue
+++ b/src/components/ZarrGroup.vue
@@ -1,0 +1,104 @@
+<template>
+  <div key="zarr-group" class="mt-2 zarr-group">
+    <b-list-group>
+      <b-list-group-item v-for="(subgroup, name) in group.groups" :key="name">
+        <div class="d-flex justify-content-between array-name">
+          <h2>
+            <code>{{ name }}</code>
+          </h2>
+        </div>
+        <ZarrGroup :group="subgroup" :group-name="name"></ZarrGroup>
+      </b-list-group-item>
+      <b-list-group-item v-for="(array, name) in group.arrays" :key="name">
+        <div class="d-flex justify-content-between array-name">
+          <h2>
+            <code>{{ name }}</code>
+          </h2>
+          <small>
+            <code>{{ array.dtype }}</code>
+          </small>
+        </div>
+        <div class="table-responsive array-dims">
+          <table class="table table-striped">
+            <thead>
+              <tr>
+                <th v-if="array.attrs._ARRAY_DIMENSIONS">Dimension</th>
+                <th v-else>Axis</th>
+                <th>Shape</th>
+                <th>Chunk Size</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="(_, i) in array.shape" :key="name + '-axis-' + i">
+                <td>
+                  <code v-if="array.attrs._ARRAY_DIMENSIONS">
+                    {{ array.attrs._ARRAY_DIMENSIONS[i] }}
+                  </code>
+                  <code v-else>{{ i }}</code>
+                </td>
+                <td>
+                  <code>{{ array.shape[i] }}</code>
+                </td>
+                <td>
+                  <code>{{ array.chunks[i] }}</code>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div v-if="hasItems(array.attrs)" class="mt-2 array-attrs">
+          <b-card no-body class="mb-1">
+            <b-card-header header-tag="header" class="p-1">
+              <b-button v-b-toggle="name + '-attrs'" block variant="light">
+                <b>Attributes</b>
+              </b-button>
+            </b-card-header>
+            <b-collapse :id="name + '-attrs'">
+              <b-card-body>
+                <dl>
+                  <template v-for="(value, key, i) in array.attrs">
+                    <dt :key="name + '-key-' + i">{{ key }}</dt>
+                    <dd :key="name + '-value-' + i">{{ value }}</dd>
+                  </template>
+                </dl>
+              </b-card-body>
+            </b-collapse>
+          </b-card>
+        </div>
+      </b-list-group-item>
+    </b-list-group>
+    <div v-if="hasItems(group.attrs)" class="mt-2 group-attrs">
+      <b-card no-body class="mb-1">
+        <b-card-header header-tag="header" class="p-1">
+          <b-button v-b-toggle="groupName + '-attrs'" block variant="light">
+            <b>Group Attributes</b>
+          </b-button>
+        </b-card-header>
+        <b-collapse :id="groupName + '-attrs'">
+          <b-card-body>
+            <dl>
+              <template v-for="(value, key, i) in group.attrs">
+                <dt :key="groupName + '-key-' + i">{{ key }}</dt>
+                <dd :key="groupName + '-value-' + i">{{ value }}</dd>
+              </template>
+            </dl>
+          </b-card-body>
+        </b-collapse>
+      </b-card>
+    </div>
+  </div>
+</template>
+
+<script>
+import { isEmpty } from "lodash";
+
+export default {
+  name: "ZarrGroup",
+  props: ["group", "groupName"],
+  methods: {
+    hasItems: function(obj) {
+      return !isEmpty(obj);
+    }
+  }
+};
+</script>

--- a/src/components/ZarrMetadataTab.vue
+++ b/src/components/ZarrMetadataTab.vue
@@ -1,0 +1,144 @@
+<template>
+  <b-tab key="zarr-metadata" title="Zarr Metadata" :active="active">
+    <div class="mt-2 zarr-arrays">
+      <b-list-group>
+        <b-list-group-item v-for="array in group.arrays" :key="array.name">
+          <div class="d-flex justify-content-between array-name">
+            <h2>
+              <code>{{ array.name }}</code>
+            </h2>
+            <small>
+              <code>{{ array.dtype }}</code>
+            </small>
+          </div>
+          <div class="table-responsive array-dims">
+            <table class="table table-striped">
+              <thead>
+                <tr>
+                  <th>Dimension</th>
+                  <th>Shape</th>
+                  <th>Chunk Size</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  v-for="(dim, i) in array.dims"
+                  :key="array.name + '-' + dim"
+                >
+                  <td>
+                    <code>{{ dim }}</code>
+                  </td>
+                  <td>
+                    <code>{{ array.shape[i] }}</code>
+                  </td>
+                  <td>
+                    <code>{{ array.chunks[i] }}</code>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div v-if="array.hasAttrs" class="mt-2 array-attrs">
+            <b-card no-body class="mb-1">
+              <b-card-header header-tag="header" class="p-1">
+                <b-button
+                  v-b-toggle="array.name + '-attrs'"
+                  block
+                  variant="light"
+                >
+                  <b>Attributes</b>
+                </b-button>
+              </b-card-header>
+              <b-collapse :id="array.name + '-attrs'">
+                <b-card-body>
+                  <dl>
+                    <template v-for="(value, key, i) in array.attrs">
+                      <dt :key="array.name + '-key-' + i">{{ key }}</dt>
+                      <dd :key="array.name + '-value-' + i">{{ value }}</dd>
+                    </template>
+                  </dl>
+                </b-card-body>
+              </b-collapse>
+            </b-card>
+          </div>
+        </b-list-group-item>
+      </b-list-group>
+    </div>
+    <div class="mt-2 zarr-attrs">
+      <b-card no-body class="mb-1">
+        <b-card-header header-tag="header" class="p-1">
+          <b-button v-b-toggle.zarr-attrs block variant="light">
+            <b>Group Attributes</b>
+          </b-button>
+        </b-card-header>
+        <b-collapse id="zarr-attrs">
+          <b-card-body>
+            <dl>
+              <template v-for="(value, key, i) in group.attrs">
+                <dt :key="'group-key-' + i">{{ key }}</dt>
+                <dd :key="'group-value-' + i">{{ value }}</dd>
+              </template>
+            </dl>
+          </b-card-body>
+        </b-collapse>
+      </b-card>
+    </div>
+  </b-tab>
+</template>
+
+<script>
+const axios = require("axios").default;
+
+function parseMeta(meta) {
+  if (!(".zgroup" in meta)) {
+    throw "Group doesn't contain the '.zgroup' key.";
+  }
+  let group = {};
+  group["zarr_format"] = meta[".zgroup"].zarr_format;
+  group["attrs"] = meta[".zattrs"];
+  let arrays = {};
+  for (const prop in meta) {
+    if (prop.endsWith("/.zarray")) {
+      let attrs = meta[prop.replace(".zarray", ".zattrs")];
+      let name = prop.split("/.zarray")[0];
+      let array = {
+        name: name,
+        dtype: meta[prop].dtype.substring(1).replace(/[a-z]/g, function(m) {
+          return { i: "int", f: "float" }[m];
+        }),
+        dims: attrs._ARRAY_DIMENSIONS,
+        shape: meta[prop].shape,
+        chunks: meta[prop].chunks,
+        hasAttrs: Object.keys(attrs).length > 1,
+        attrs: attrs
+      };
+      delete array.attrs._ARRAY_DIMENSIONS;
+      arrays[name] = array;
+    }
+  }
+  group["arrays"] = arrays;
+  return group;
+}
+
+export default {
+  name: "ZarrMetadataTab",
+  props: ["active", "zarrMetadataUrl"],
+  data() {
+    return {
+      loading: true,
+      errored: false,
+      group: {}
+    };
+  },
+  mounted() {
+    axios
+      .get(this.zarrMetadataUrl)
+      .then(response => (this.group = parseMeta(response.data.metadata)))
+      .catch(error => {
+        console.log(error);
+        this.errored = true;
+      })
+      .finally(() => (this.loading = false));
+  }
+};
+</script>

--- a/src/components/ZarrMetadataTab.vue
+++ b/src/components/ZarrMetadataTab.vue
@@ -1,6 +1,11 @@
 <template>
   <b-tab key="zarr-metadata" title="Zarr Metadata" :active="active">
-    <div class="mt-2 zarr-arrays">
+    <div v-if="loading" class="mt-2"></div>
+    <div v-else-if="errored" class="mt-2">
+      <p>An error has occurred while loading while loading Zarr metadata.</p>
+      <p>Check the console.</p>
+    </div>
+    <div v-else class="mt-2 zarr-arrays">
       <b-list-group>
         <b-list-group-item v-for="array in group.arrays" :key="array.name">
           <div class="d-flex justify-content-between array-name">
@@ -63,25 +68,25 @@
           </div>
         </b-list-group-item>
       </b-list-group>
-    </div>
-    <div class="mt-2 zarr-attrs">
-      <b-card no-body class="mb-1">
-        <b-card-header header-tag="header" class="p-1">
-          <b-button v-b-toggle.zarr-attrs block variant="light">
-            <b>Group Attributes</b>
-          </b-button>
-        </b-card-header>
-        <b-collapse id="zarr-attrs">
-          <b-card-body>
-            <dl>
-              <template v-for="(value, key, i) in group.attrs">
-                <dt :key="'group-key-' + i">{{ key }}</dt>
-                <dd :key="'group-value-' + i">{{ value }}</dd>
-              </template>
-            </dl>
-          </b-card-body>
-        </b-collapse>
-      </b-card>
+      <div class="mt-2 zarr-attrs">
+        <b-card no-body class="mb-1">
+          <b-card-header header-tag="header" class="p-1">
+            <b-button v-b-toggle.zarr-attrs block variant="light">
+              <b>Group Attributes</b>
+            </b-button>
+          </b-card-header>
+          <b-collapse id="zarr-attrs">
+            <b-card-body>
+              <dl>
+                <template v-for="(value, key, i) in group.attrs">
+                  <dt :key="'group-key-' + i">{{ key }}</dt>
+                  <dd :key="'group-value-' + i">{{ value }}</dd>
+                </template>
+              </dl>
+            </b-card-body>
+          </b-collapse>
+        </b-card>
+      </div>
     </div>
   </b-tab>
 </template>
@@ -127,6 +132,7 @@ export default {
     return {
       loading: true,
       errored: false,
+      error: null,
       group: {}
     };
   },
@@ -134,8 +140,8 @@ export default {
     axios
       .get(this.zarrMetadataUrl)
       .then(response => (this.group = parseMeta(response.data.metadata)))
-      .catch(error => {
-        console.log(error);
+      .catch(err => {
+        console.error(err);
         this.errored = true;
       })
       .finally(() => (this.loading = false));

--- a/src/components/ZarrMetadataTab.vue
+++ b/src/components/ZarrMetadataTab.vue
@@ -5,128 +5,17 @@
       <p>An error has occurred while loading while loading Zarr metadata.</p>
       <p>Check the console.</p>
     </div>
-    <div v-else class="mt-2 zarr-arrays">
-      <b-list-group>
-        <b-list-group-item v-for="array in group.arrays" :key="array.name">
-          <div class="d-flex justify-content-between array-name">
-            <h2>
-              <code>{{ array.name }}</code>
-            </h2>
-            <small>
-              <code>{{ array.dtype }}</code>
-            </small>
-          </div>
-          <div class="table-responsive array-dims">
-            <table class="table table-striped">
-              <thead>
-                <tr>
-                  <th>Dimension</th>
-                  <th>Shape</th>
-                  <th>Chunk Size</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr
-                  v-for="(dim, i) in array.dims"
-                  :key="array.name + '-' + dim"
-                >
-                  <td>
-                    <code>{{ dim }}</code>
-                  </td>
-                  <td>
-                    <code>{{ array.shape[i] }}</code>
-                  </td>
-                  <td>
-                    <code>{{ array.chunks[i] }}</code>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-          <div v-if="array.hasAttrs" class="mt-2 array-attrs">
-            <b-card no-body class="mb-1">
-              <b-card-header header-tag="header" class="p-1">
-                <b-button
-                  v-b-toggle="array.name + '-attrs'"
-                  block
-                  variant="light"
-                >
-                  <b>Attributes</b>
-                </b-button>
-              </b-card-header>
-              <b-collapse :id="array.name + '-attrs'">
-                <b-card-body>
-                  <dl>
-                    <template v-for="(value, key, i) in array.attrs">
-                      <dt :key="array.name + '-key-' + i">{{ key }}</dt>
-                      <dd :key="array.name + '-value-' + i">{{ value }}</dd>
-                    </template>
-                  </dl>
-                </b-card-body>
-              </b-collapse>
-            </b-card>
-          </div>
-        </b-list-group-item>
-      </b-list-group>
-      <div class="mt-2 zarr-attrs">
-        <b-card no-body class="mb-1">
-          <b-card-header header-tag="header" class="p-1">
-            <b-button v-b-toggle.zarr-attrs block variant="light">
-              <b>Group Attributes</b>
-            </b-button>
-          </b-card-header>
-          <b-collapse id="zarr-attrs">
-            <b-card-body>
-              <dl>
-                <template v-for="(value, key, i) in group.attrs">
-                  <dt :key="'group-key-' + i">{{ key }}</dt>
-                  <dd :key="'group-value-' + i">{{ value }}</dd>
-                </template>
-              </dl>
-            </b-card-body>
-          </b-collapse>
-        </b-card>
-      </div>
-    </div>
+    <ZarrGroup v-else :group="group" :group-name="root"></ZarrGroup>
   </b-tab>
 </template>
 
 <script>
-const axios = require("axios").default;
-
-function parseMeta(meta) {
-  if (!(".zgroup" in meta)) {
-    throw "Group doesn't contain the '.zgroup' key.";
-  }
-  let group = {};
-  group["zarr_format"] = meta[".zgroup"].zarr_format;
-  group["attrs"] = meta[".zattrs"];
-  let arrays = {};
-  for (const prop in meta) {
-    if (prop.endsWith("/.zarray")) {
-      let attrs = meta[prop.replace(".zarray", ".zattrs")];
-      let name = prop.split("/.zarray")[0];
-      let array = {
-        name: name,
-        dtype: meta[prop].dtype.substring(1).replace(/[a-z]/g, function(m) {
-          return { i: "int", f: "float" }[m];
-        }),
-        dims: attrs._ARRAY_DIMENSIONS,
-        shape: meta[prop].shape,
-        chunks: meta[prop].chunks,
-        hasAttrs: Object.keys(attrs).length > 1,
-        attrs: attrs
-      };
-      delete array.attrs._ARRAY_DIMENSIONS;
-      arrays[name] = array;
-    }
-  }
-  group["arrays"] = arrays;
-  return group;
-}
+import ZarrGroup from "./ZarrGroup.vue";
+import fetch from "node-fetch";
 
 export default {
   name: "ZarrMetadataTab",
+  components: { ZarrGroup },
   props: ["active", "zarrMetadataUrl"],
   data() {
     return {
@@ -137,14 +26,43 @@ export default {
     };
   },
   mounted() {
-    axios
-      .get(this.zarrMetadataUrl)
-      .then(response => (this.group = parseMeta(response.data.metadata)))
+    fetch(this.zarrMetadataUrl)
+      .then(rsp => rsp.json())
+      .then(data => (this.group = this.parseMeta(data.metadata)))
       .catch(err => {
         console.error(err);
         this.errored = true;
       })
       .finally(() => (this.loading = false));
+  },
+  methods: {
+    parseMeta: function(meta) {
+      const group = { groups: {}, arrays: {}, attrs: meta[".zattrs"] || {} };
+      for (const prop in meta)
+        if (!prop.endsWith(".zattrs")) {
+          prop
+            .split("/")
+            .slice(0, -1)
+            .reduce((pre, cur, idx, arr) => {
+              if (idx == arr.length - 1) {
+                if (prop.endsWith(".zgroup"))
+                  return (pre.groups[cur] = {
+                    groups: {},
+                    arrays: {},
+                    attrs: meta[prop.replace(".zgroup", ".zattrs")] || {}
+                  });
+                else
+                  return (pre.arrays[cur] = {
+                    dtype: meta[prop].dtype,
+                    shape: meta[prop].shape,
+                    chunks: meta[prop].chunks,
+                    attrs: meta[prop.replace(".zarray", ".zattrs")] || {}
+                  });
+              } else return pre.groups[cur];
+            }, group);
+        }
+      return group;
+    }
   }
 };
 </script>

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -281,7 +281,7 @@ export default {
         x.roles.includes("zarr-consolidated-metadata")
       );
 
-      if (typeof zarrMetadata !== undefined) {
+      if (typeof zarrMetadata !== 'undefined') {
         return zarrMetadata.href;
       }
       return null;

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -281,7 +281,7 @@ export default {
         x.roles.includes("zarr-consolidated-metadata")
       );
 
-      if (zarrMetadata != null) {
+      if (typeof zarrMetadata !== 'undefined') {
         return zarrMetadata.href;
       }
       return null;

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -275,6 +275,12 @@ export default {
       }
 
       return this.id;
+    },
+    zarrMetadataUrl() {
+      return (
+        this.assets.find(x => x.roles.includes("zarr-consolidated-metadata"))
+          .href || null
+      );
     }
   },
   watch: {

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -277,10 +277,14 @@ export default {
       return this.id;
     },
     zarrMetadataUrl() {
-      return (
-        this.assets.find(x => x.roles.includes("zarr-consolidated-metadata"))
-          .href || null
+      const zarrMetadata = this.assets.find(x =>
+        x.roles.includes("zarr-consolidated-metadata")
       );
+
+      if (zarrMetadata != null) {
+        return zarrMetadata.href;
+      }
+      return null;
     }
   },
   watch: {

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -281,7 +281,7 @@ export default {
         x.roles.includes("zarr-consolidated-metadata")
       );
 
-      if (typeof zarrMetadata !== 'undefined') {
+      if (typeof zarrMetadata !== undefined) {
         return zarrMetadata.href;
       }
       return null;


### PR DESCRIPTION
This PR adds a tab to view the metadata of a consolidated Zarr data store, conditional on the existence of an asset with the `"zarr-consolidated-metadata"` role, as discussed in #44:

![screenshot of Zarr metadata tab in action](https://user-images.githubusercontent.com/20627856/97036770-509fcf80-1536-11eb-9f8d-9b6821b34e44.png)

This introduces the following changes:

- Adds [axios](https://www.npmjs.com/package/axios) to dependencies in [package.json](https://github.com/charlesbluca/stac-browser/blob/add-zarr-tab/package.json#L19) to perform the GET request of the metadata file
- Adds `zarrMetadataUrl` as a computed property in [common.js](https://github.com/charlesbluca/stac-browser/blob/add-zarr-tab/src/components/common.js#L279) returning the `href` of the appropriate asset, if it exists
- Adds `ZarrMetadataTab` component to [Catalog.vue](https://github.com/charlesbluca/stac-browser/blob/add-zarr-tab/src/components/Catalog.vue#L128) to be visible and active on the existence of a `zarrMetadataUrl`
- Creates [ZarrMetadataTab.vue](https://github.com/charlesbluca/stac-browser/blob/add-zarr-tab/src/components/ZarrMetadataTab.vue) to handle the downloading, parsing, and rendering of the Zarr metadata

If present, the tab represents each array of the Zarr data store as an item in a Bootstrap list group, with a table listing its dimensions and their corresponding shape/chunk size, and a collapsible card containing additional metadata:

![screenshot of array attributes card](https://user-images.githubusercontent.com/20627856/97035810-e20e4200-1534-11eb-8109-4055c952a0e4.png)


Below the list of arrays is a similar card containing all group-level attributes:

![screenshot of group attributes card](https://user-images.githubusercontent.com/20627856/97035739-c5720a00-1534-11eb-815f-92bcf20d5b88.png)

An example of a Collection with accessible Zarr metadata (which I used for testing) can be found at:

- https://raw.githubusercontent.com/pangeo-data/pangeo-datastore-stac/master/test_zarr/collection.json

An example of a Collection with _inaccessible_ Zarr metadata (due to CORS headers not being set in the containing bucket) can be found at:

- https://raw.githubusercontent.com/pangeo-data/pangeo-datastore-stac/master/master/ocean/sea_surface_height/collection.json

In the case of an error, a message appears where the arrays and attributes would have normally been. I left this intentionally vague for now in case a better solution is recommended (disabling the tab, placing the error message elsewhere on the page, etc.):

![screenshot of a sample error message](https://user-images.githubusercontent.com/20627856/97036615-16cec900-1536-11eb-905e-f73b74b0794d.png)

Other than that, some other factors to consider:

- Should any more properties be present for each Zarr array?
- Are there any properties which could be laid out in a different fashion?
- Can the styling be altered to better mesh with other elements of the STAC browser?
