### PR TITLE
Support API Collections + bug fixes

### DIFF
--- a/src/components/Catalog.vue
+++ b/src/components/Catalog.vue
@@ -207,6 +207,8 @@ import MetadataSidebar from './MetadataSidebar.vue'
 
 import { transformCatalog } from "../migrate"
 
+import { fetchUri } from "../util";
+
 const ITEMS_PER_PAGE = 25;
 
 export default {
@@ -304,7 +306,7 @@ export default {
         }
 
         try {
-          const rsp = await fetch(externalCollections.href);
+          const rsp = await fetchUri(externalCollections.href);
           if (!rsp.ok) {
             console.warn(await rsp.text());
             return [];
@@ -333,14 +335,15 @@ export default {
                 }
               }
 
-              const slug = this.slugify(this.resolve(href, this.url));
+              const resolved = this.resolve(href, this.url);
+              const slug = this.slugify(resolved);
               const to = [p, slug].join("");
 
               return Object.assign(collection, {
                 path: href,
                 to,
                 title: collection.title || collection.id || href,
-                url: this.resolve(href, this.url)
+                url: resolved
               });
             });
         } catch (err) {
@@ -361,7 +364,7 @@ export default {
         }
 
         try {
-          const rsp = await fetch(
+          const rsp = await fetchUri(
             `${externalItemsLink.href}?page=${this.currentItemPage}`
           );
 
@@ -454,7 +457,8 @@ export default {
             p += "/";
           }
 
-          const slug = this.slugify(this.resolve(child.href, this.url));
+          const resolved = this.resolve(child.href, this.url);
+          const slug = this.slugify(resolved);
           const to = [p, slug].join("");
 
           return {
@@ -462,7 +466,7 @@ export default {
             to,
             // child.id is a workaround for https://earthengine-stac.storage.googleapis.com/catalog/catalog.json
             title: child.title || child.id || child.href,
-            url: this.resolve(child.href, this.url)
+            url: resolved
           };
         });
     },

--- a/src/components/Catalog.vue
+++ b/src/components/Catalog.vue
@@ -444,10 +444,12 @@ export default {
       return this.children.length;
     },
     children() {
-      return this.links.filter(x => x.rel === "child")
+      return this.links
+        .filter(x => x.rel === "child")
         .map(child => {
           // strip /collection from the target path
           let p = this.path.replace(/^\/collection/, "");
+
           if (!p.endsWith("/")) {
             p += "/";
           }

--- a/src/components/MetadataSidebar.vue
+++ b/src/components/MetadataSidebar.vue
@@ -47,7 +47,7 @@
                 <td v-html="prop.value" />
                 </tr>
             </template>
-            <template v-if="providers">
+            <template v-if="Array.isArray(providers) && providers.length > 0">
                 <tr>
                 <td colspan="2" class="group">
                     <h4>

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -5,7 +5,6 @@ import clone from "clone";
 import { HtmlRenderer, Parser } from "commonmark";
 import escape from "lodash.escape";
 import isEqual from "lodash.isequal";
-import isEmpty from "lodash.isempty";
 import jsonQuery from "json-query";
 import spdxToHTML from "spdx-to-html";
 import spdxLicenseIds from "spdx-license-ids";

--- a/src/main.js
+++ b/src/main.js
@@ -99,7 +99,13 @@ const main = async () => {
   };
 
   const catalogValidator = async (data) => {
-    if (data.license != null || data.extent != null) {
+    if (Array.isArray(data.collections) && Array.isArray(data.links)) {
+      // TODO: Validate the Collections API (/collections)
+      // Skip Collections API validation for now
+      return null;
+    }
+
+    if (data.license || data.extent) {
       // contains Collection properties
       return collectionValidator(data);
     }

--- a/src/main.js
+++ b/src/main.js
@@ -99,12 +99,6 @@ const main = async () => {
   };
 
   const catalogValidator = async (data) => {
-    if (Array.isArray(data.collections) && Array.isArray(data.links)) {
-      // TODO: Validate the Collections API (/collections)
-      // Skip Collections API validation for now
-      return null;
-    }
-
     if (data.license || data.extent) {
       // contains Collection properties
       return collectionValidator(data);

--- a/src/migrate.js
+++ b/src/migrate.js
@@ -1,6 +1,6 @@
 /* Methods that transform STAC object JSON from older versions to
 allow for a more consistent usage in other parts of the codebase */
-import { STAC_VERISON } from './config';
+import { STAC_VERSION } from './config';
 
 export const transformCatalog = (entity) => {
     if(!entity) { return entity; }


### PR DESCRIPTION
A first attempt to implement better STAC API support. #48
This allows to show collections that have been referenced the OAFeat way (rel type data on landing page).
Some additional bug fixes sneaked in, see comments. May help a bit with #58?

Demo: https://stacindex.org/catalogs/google-earth-engine-openeo#/?t=collections
