### PR TITLE
Improvements for Summaries

### DIFF
--- a/src/components/Catalog.vue
+++ b/src/components/Catalog.vue
@@ -328,6 +328,7 @@ export default {
     bands() {
       return (
         this._properties["eo:bands"] ||
+        this.summaries['eo:bands'] ||
         (this.rootCatalog &&
           this.rootCatalog.properties &&
           this.rootCatalog.properties["eo:bands"]) ||
@@ -567,7 +568,7 @@ export default {
       return bbox;
     },
     summaries() {
-      return this.catalog.summaries;
+      return this.catalog.summaries || {};
     },
     tabIndex: {
       get: function() {

--- a/src/components/MetadataSidebar.vue
+++ b/src/components/MetadataSidebar.vue
@@ -187,4 +187,7 @@ export default {
   font-weight: bold;
   color: #ddd;
 }
+#stac-browser .metadata-object .metadata-object {
+    margin-left: 1em;
+}
 </style>

--- a/src/components/MetadataSidebar.vue
+++ b/src/components/MetadataSidebar.vue
@@ -79,8 +79,8 @@
             </template>
             <template v-if="summaries">
                 <tr>
-                <td colspan="2" class="group">
-                    <h4>Summaries</h4>
+                <td colspan="2" class="group summary">
+                    <h4>Item Summary</h4>
                 </td>
                 </tr>
                 <template v-for="(props, ext) in summariesList">
@@ -90,7 +90,7 @@
                     </td>
                 </tr>
                 <tr v-for="prop in props" :key="prop.key">
-                    <td class="summary-title" >
+                    <td class="title summary-title" >
                         <!-- eslint-disable-next-line vue/no-v-html -->
                         <span :title="prop.key" v-html="prop.label" />
                     </td>
@@ -113,15 +113,15 @@ const propertyDefinitions = getPropertyDefinitions(),
   propertyMap = propertyDefinitions.properties,
   groupMap = propertyDefinitions.groups;
 
-const constructPropList = (props, skip = () => false) => {
+const constructPropList = (props, summaries = false, skip = () => false) => {
     return Object.entries(props || [])
-                .filter(([, v]) => Number.isFinite(v) || !isEmpty(v))
+                .filter(([, v]) => Number.isFinite(v) || !isEmpty(v) || (summaries && Array.isArray(v) && v.length == 0)) // last part: Skip empty summaries
                 .filter(([k]) => !skip(k))
                 .sort(([a], [b]) => a - b)
                 .map(([key, value]) => ({
                     key,
                     label: propertyDefinitions.formatPropertyLabel(key),
-                    value: propertyDefinitions.formatPropertyValue(key, value)
+                    value: summaries ? propertyDefinitions.formatSummaryValues(key, value) : propertyDefinitions.formatPropertyValue(key, value)
                 }))
                 .reduce((acc, prop) => {
                     let ext = "";
@@ -160,12 +160,12 @@ export default {
             return null;
         },
         summariesList() {
-            return constructPropList(this.summaries);
+            const skip = key => propertyMap[key] && propertyMap[key].skip;
+            return constructPropList(this.summaries, true, skip);
         },
         propertyList() {
             const skip = key => propertyMap[key] && propertyMap[key].skip;
-
-            return constructPropList(this.properties, skip);
+            return constructPropList(this.properties, false, skip);
         },
     }
 };
@@ -176,5 +176,15 @@ export default {
 .summary-title {
     font-weight: bold;
     width: 40%;
+}
+</style>
+<style>
+#stac-browser .table td.group.summary {
+  background-color: #555;
+}
+
+#stac-browser .table td.group.summary h4 {
+  font-weight: bold;
+  color: #ddd;
 }
 </style>

--- a/src/components/MetadataSidebar.vue
+++ b/src/components/MetadataSidebar.vue
@@ -179,15 +179,15 @@ export default {
 }
 </style>
 <style>
-#stac-browser .table td.group.summary {
+.table td.group.summary {
   background-color: #555;
 }
 
-#stac-browser .table td.group.summary h4 {
+.table td.group.summary h4 {
   font-weight: bold;
   color: #ddd;
 }
-#stac-browser .metadata-object .metadata-object {
+.metadata-object .metadata-object {
     margin-left: 1em;
 }
 </style>

--- a/src/components/MetadataSidebar.vue
+++ b/src/components/MetadataSidebar.vue
@@ -77,7 +77,7 @@
                 </tr>
                 </template>
             </template>
-            <template v-if="summaries">
+            <template v-if="hasSummary">
                 <tr>
                 <td colspan="2" class="group summary">
                     <h4>Item Summary</h4>
@@ -158,6 +158,9 @@ export default {
             }
 
             return null;
+        },
+        hasSummary() {
+            return Object.keys(this.summaries).length > 0;
         },
         summariesList() {
             const skip = key => propertyMap[key] && propertyMap[key].skip;

--- a/src/properties.js
+++ b/src/properties.js
@@ -3,6 +3,31 @@
 const enrichPropertyDefinitions = (propertyDefinitions) => {
   const propertyMap = propertyDefinitions.properties;
 
+  const formatArray = (key, values, sort = false) => {
+    let list = values;
+    if (sort) {
+      list = list.slice(0).sort();
+    }
+    list = list.map(v => formatValue(key, v));
+    if (list.length > 1) {
+      return "<ul><li>" + list.join("</li><li>") + "</li></ul>";
+    }
+    else {
+      return list[0];
+    }
+  }
+  
+  const formatObject = (key, obj) => {
+    let props = [];
+    for(let type in obj) {
+      let label = type.split(":").map(part => part.substr(0, 1).toUpperCase() + part.substr(1));
+      let formatted = formatValue(key, obj[type]);
+      props.push(`<strong>${label}</strong>: ${formatted}`);
+    }
+    return props.join("<br />");
+  }
+  
+
   const formatValue = (key, value) => {
     let suffix = "";
   
@@ -98,16 +123,11 @@ const enrichPropertyDefinitions = (propertyDefinitions) => {
     }
   
     if (Array.isArray(value)) {
-      return value.map(v => {
-        if (typeof (v) === "object") {
-          return JSON.stringify(v);
-        }
-        return v;
-      });
+      return formatArray(key, value);
     }
   
     if (typeof value === "object") {
-      return JSON.stringify(value);
+      return formatObject(key, value);
     }
   
     return value + suffix;
@@ -124,23 +144,10 @@ const enrichPropertyDefinitions = (propertyDefinitions) => {
     },
     formatSummaryValues: (key, values) => {
       if (Array.isArray(values)) {
-        let list = values.sort().map(v => formatValue(key, v))
-        if (list.length > 1) {
-          return "<ul><li>" + list.join("</li><li>") + "</li></ul>";
-        }
-        else {
-          return list[0];
-        }
+        return formatArray(key, values, true);
       }
       else if (values && typeof values === 'object') {
-        let lines = [];
-        for(let type in values) {
-          let c1 = type.substr(0, 1).toUpperCase();
-          let rest = type.substr(1);
-          let tval = formatValue(key, values[type]);
-          lines.push(`<strong>${c1}${rest}</strong>: ${tval}`);
-        }
-        return lines.join("<br />");
+        return formatObject(key, values);
       }
       
       return formatValue(key, values);

--- a/src/properties.js
+++ b/src/properties.js
@@ -10,7 +10,7 @@ const enrichPropertyDefinitions = (propertyDefinitions) => {
     }
     list = list.map(v => formatValue(key, v));
     if (list.length > 1) {
-      return "<ul><li>" + list.join("</li><li>") + "</li></ul>";
+      return `<ul><li>${list.join("</li><li>")}</li></ul>`;
     }
     else {
       return list[0];
@@ -24,7 +24,7 @@ const enrichPropertyDefinitions = (propertyDefinitions) => {
       let formatted = formatValue(key, obj[type]);
       props.push(`<strong>${label}</strong>: ${formatted}`);
     }
-    return props.join("<br />");
+    return `<div class="metadata-object">${props.join("<br />")}</div>`;
   }
   
 


### PR DESCRIPTION
This implements some improvements for summaries:
1. Try to visualize that this is a new "chapter" with subheadings by making the cell darker
2. Properly take care of arrays and min/max objects in summaries
3. Show bands in a separate tab like for items
4. Skip complex objects like in items, too

Demo: https://stacindex.org/catalogs/google-earth-engine-openeo#/pZNDdRmTV2iPd3s8ozEEjRTGr6iNwhzNQx?t=collections