### PR TITLE
Add external pagination support

### DIFF
--- a/src/components/Catalog.vue
+++ b/src/components/Catalog.vue
@@ -410,7 +410,9 @@ export default {
           Object.keys(this.externalPaginationLinks).forEach(linkRelation => {
             const link = items.links.find(link => link && link.rel === linkRelation && typeof link.href === 'string');
             if (link && typeof link.href === 'string') {
-              this.externalPaginationLinks[linkRelation] = `${this.slugify(link.href.replace(this.ancestors[0], '').replace('/items', ''))}`;
+              const externalPaginationUrl = new URL(this.url)
+              new URL(link.href).searchParams.forEach((value, key) => externalPaginationUrl.searchParams.set(key, value));
+              this.externalPaginationLinks[linkRelation] = this.slugify(externalPaginationUrl.toString());
             } else {
               this.externalPaginationLinks[linkRelation] = null;
             }

--- a/src/components/Catalog.vue
+++ b/src/components/Catalog.vue
@@ -142,9 +142,9 @@
                 :per-page="itemsPerPage"
                 :hide-goto-end-buttons="true"
               />
-              <ul v-else-if="hasExternalPagination" class="pagination external-pagination">
+              <ul v-else-if="hasExternalPagination" class="pagination">
                 <ExternalPaginationLink v-if="showFirstAndLastExternalPaginationLink" :to="externalPaginationLinks.first" name="First" />
-                <ExternalPaginationLink :to="externalPaginationLinks.previous" name="Previous" />
+                <ExternalPaginationLink :to="externalPaginationLinks.previous || externalPaginationLinks.prev" name="Previous" />
                 <ExternalPaginationLink :to="externalPaginationLinks.next" name="Next" />
                 <ExternalPaginationLink v-if="showFirstAndLastExternalPaginationLink" :to="externalPaginationLinks.last" name="Last" />
               </ul>
@@ -263,9 +263,10 @@ export default {
       externalItemCount: 0,
       externalItemsPerPage: 0,
       externalItemPaging: false,
-      externalPaginationRelations: ['first', 'previous', 'next', 'last'],
+      externalPaginationRelations: ['first', 'prev', 'previous', 'next', 'last'],
       externalPaginationLinks: {
         first: null,
+        prev: null,
         previous: null,
         next: null,
         last: null
@@ -926,10 +927,5 @@ td.provider .description {
   height: 200px;
   width: 100%;
   margin-bottom: 10px;
-}
-
-.external-pagination .page-link {
-  text-transform: capitalize;
-  cursor: pointer;
 }
 </style>

--- a/src/components/Catalog.vue
+++ b/src/components/Catalog.vue
@@ -410,8 +410,18 @@ export default {
           Object.keys(this.externalPaginationLinks).forEach(linkRelation => {
             const link = items.links.find(link => link && link.rel === linkRelation && typeof link.href === 'string');
             if (link && typeof link.href === 'string') {
-              const externalPaginationUrl = new URL(this.url)
-              new URL(link.href).searchParams.forEach((value, key) => externalPaginationUrl.searchParams.set(key, value));
+              const externalPaginationUrl = new URL(this.url);
+              const searchParams = new URL(link.href).searchParams;
+              // removing any non present URL params in the pagination link from the current URL
+              // so that "First" link is not tainted by URL param from the current page
+              externalPaginationUrl.searchParams.forEach((value, key) => {
+                if (!searchParams.has(key)) {
+                  externalPaginationUrl.searchParams.delete(key);
+                }
+              })
+              // passing any pagination URL param to the link
+              searchParams.forEach((value, key) => externalPaginationUrl.searchParams.set(key, value));
+
               this.externalPaginationLinks[linkRelation] = this.slugify(externalPaginationUrl.toString());
             } else {
               this.externalPaginationLinks[linkRelation] = null;

--- a/src/components/Catalog.vue
+++ b/src/components/Catalog.vue
@@ -143,12 +143,10 @@
                 :hide-goto-end-buttons="true"
               />
               <ul v-else-if="hasExternalPagination" class="pagination external-pagination">
-                <li class="page-item" :class="{ 'disabled': !link}" v-for="(link, linkRelation) in externalPaginationLinks" :key="linkRelation">
-                  <router-link :to="link" v-if="link" class="page-link">
-                    {{ linkRelation }}
-                  </router-link>
-                  <a class="page-link" v-else>{{ linkRelation }}</a>
-                </li>
+                <ExternalPaginationLink v-if="showFirstAndLastExternalPaginationLink" :to="externalPaginationLinks.first" name="First" />
+                <ExternalPaginationLink :to="externalPaginationLinks.previous" name="Previous" />
+                <ExternalPaginationLink :to="externalPaginationLinks.next" name="Next" />
+                <ExternalPaginationLink v-if="showFirstAndLastExternalPaginationLink" :to="externalPaginationLinks.last" name="Last" />
               </ul>
             </b-tab>
             <b-tab
@@ -217,6 +215,7 @@ import { mapActions, mapGetters } from "vuex";
 import common from "./common";
 import AssetTab from './AssetTab.vue'
 import MetadataSidebar from './MetadataSidebar.vue'
+import ExternalPaginationLink from "./ExternalPaginationLink.vue";
 
 import { transformCatalog } from "../migrate"
 
@@ -254,6 +253,7 @@ export default {
     }
   },
   components: {
+    ExternalPaginationLink,
     AssetTab,
     ZarrMetadataTab: () => import('./ZarrMetadataTab.vue'),
     MetadataSidebar
@@ -263,6 +263,7 @@ export default {
       externalItemCount: 0,
       externalItemsPerPage: 0,
       externalItemPaging: false,
+      externalPaginationRelations: ['first', 'previous', 'next', 'last'],
       externalPaginationLinks: {
         first: null,
         previous: null,
@@ -414,11 +415,6 @@ export default {
               this.externalPaginationLinks[linkRelation] = null;
             }
           });
-          // if external pagination doesn't include first or last link, we remove those two entries so that links are not rendered on the UI for them
-          if (this.externalPaginationLinks.first === null && this.externalPaginationLinks.last === null) {
-            delete this.externalPaginationLinks.first;
-            delete this.externalPaginationLinks.last;
-          }
 
           // strip /collection from the target path
           let p = this.path.replace(/^\/collection/, "");
@@ -765,6 +761,9 @@ export default {
     hasExternalPagination() {
       return Object.values(this.externalPaginationLinks).filter(link => link !== null).length > 0
     },
+    showFirstAndLastExternalPaginationLink() {
+      return this.externalPaginationLinks.first !== null || this.externalPaginationLinks.last !== null
+    }
   },
   watch: {
     ...common.watch,

--- a/src/components/Catalog.vue
+++ b/src/components/Catalog.vue
@@ -404,8 +404,8 @@ export default {
           } else {
             this.externalItemCount = items.features.length;
           }
-          ['first', 'previous', 'next', 'last'].forEach(linkRelation => {
-            const link = items.links.find(link => link.rel === linkRelation);
+          Object.keys(this.externalPaginationLinks).forEach(linkRelation => {
+            const link = items.links.find(link => link && link.rel === linkRelation && typeof link.href === 'string');
             this.externalPaginationLinks[linkRelation] = link ? link.href : null;
           });
 
@@ -747,11 +747,7 @@ export default {
       ].filter(x => x != null && x !== false);
     },
     hasExternalPagination() {
-      let hasOneExternalLinkDefined = false;
-      Object.values(this.externalPaginationLinks).forEach(link => {
-        hasOneExternalLinkDefined ||= link !== null;
-      })
-      return hasOneExternalLinkDefined;
+      return Object.values(this.externalPaginationLinks).filter(link => link !== null).length > 0
     },
   },
   watch: {

--- a/src/components/Catalog.vue
+++ b/src/components/Catalog.vue
@@ -135,15 +135,14 @@
                 <!-- TODO row-details w/ additional metadata + map -->
               </b-table>
               <b-pagination
-                v-if="!hasExternalPagination"
-                v-show="itemCount > itemsPerPage"
+                v-if="!hasExternalPagination && itemCount > itemsPerPage"
                 v-model="currentItemPage"
                 :limit="15"
                 :total-rows="itemCount"
                 :per-page="itemsPerPage"
                 :hide-goto-end-buttons="true"
               />
-              <ul v-else class="pagination">
+              <ul v-else-if="hasExternalPagination" class="pagination">
                 <li class="page-item" :class="{ 'disabled': !previousItemsLink}">
                     <a class="page-link" @click="goToPreviousItems">Previous</a>
                 </li>
@@ -504,11 +503,11 @@ export default {
       if (!externalItemsLink) {
         return null;
       }
-      let externalItemsURL = `${externalItemsLink.href}?limit=${ITEMS_PER_PAGE}`
+      let externalItemsURL = `${externalItemsLink.href}?limit=${ITEMS_PER_PAGE}`;
       if (!this.hasExternalPagination) {
-        externalItemsURL += `&page=${this.currentItemPage}`
+        externalItemsURL += `&page=${this.currentItemPage}`;
       }
-      return externalItemsURL
+      return externalItemsURL;
     },
     itemCount() {
       if (!this.hasExternalItems) {
@@ -747,7 +746,7 @@ export default {
       ].filter(x => x != null && x !== false);
     },
     hasExternalPagination() {
-      return this.previousItemsLink || this.nextItemsLink
+      return this.previousItemsLink || this.nextItemsLink;
     },
   },
   watch: {
@@ -872,16 +871,16 @@ export default {
       this.selectedTab = qs.t;
       this.currentChildPage = Number(qs.cp) || 1;
       this.currentItemPage = Number(qs.ip) || 1;
-      this.currentExternalItemsURL = qs.eiu ? String(qs.eiu) : this.externalItemsURL
+      this.currentExternalItemsURL = qs.eiu ? String(qs.eiu) : this.externalItemsURL;
       // If we have external items, the b-table needs to "stay" on page 1 as
       // the items list only contains the number of items we want to show.
       this.currentItemListPage = this.hasExternalItems ? 1 : this.currentItemPage;
     },
     goToNextItems() {
-      this.currentExternalItemsURL = this.nextItemsLink
+      this.currentExternalItemsURL = this.nextItemsLink;
     },
     goToPreviousItems() {
-      this.currentExternalItemsURL = this.previousItemsLink
+      this.currentExternalItemsURL = this.previousItemsLink;
     }
   }
 };

--- a/src/components/Catalog.vue
+++ b/src/components/Catalog.vue
@@ -263,7 +263,6 @@ export default {
       externalItemCount: 0,
       externalItemsPerPage: 0,
       externalItemPaging: false,
-      externalPaginationRelations: ['first', 'prev', 'previous', 'next', 'last'],
       externalPaginationLinks: {
         first: null,
         prev: null,

--- a/src/components/ExternalPaginationLink.vue
+++ b/src/components/ExternalPaginationLink.vue
@@ -1,7 +1,9 @@
 <template>
-  <li class="page-item" :class="{ 'disabled': to === null}">
-    <router-link v-if="to !== null" :to="to" class="page-link">{{ name }}</router-link>
-    <a class="page-link" v-else>{{ name }}</a>
+  <li class="page-item" :class="{ disabled: to === null }">
+    <router-link v-if="to !== null" :to="to" class="page-link">{{
+      name
+    }}</router-link>
+    <a v-else class="page-link">{{ name }}</a>
   </li>
 </template>
 <script>
@@ -16,5 +18,5 @@ export default {
       required: true
     }
   }
-}
+};
 </script>

--- a/src/components/ExternalPaginationLink.vue
+++ b/src/components/ExternalPaginationLink.vue
@@ -20,3 +20,9 @@ export default {
   }
 };
 </script>
+<style scoped>
+.page-link {
+  text-transform: capitalize;
+  cursor: pointer;
+}
+</style>

--- a/src/components/ExternalPaginationLink.vue
+++ b/src/components/ExternalPaginationLink.vue
@@ -1,0 +1,20 @@
+<template>
+  <li class="page-item" :class="{ 'disabled': to === null}">
+    <router-link v-if="to !== null" :to="to" class="page-link">{{ name }}</router-link>
+    <a class="page-link" v-else>{{ name }}</a>
+  </li>
+</template>
+<script>
+export default {
+  props: {
+    to: {
+      type: [String, null],
+      default: null
+    },
+    name: {
+      type: String,
+      required: true
+    }
+  }
+}
+</script>

--- a/src/migrate.js
+++ b/src/migrate.js
@@ -1,22 +1,24 @@
 /* Methods that transform STAC object JSON from older versions to
 allow for a more consistent usage in other parts of the codebase */
-import { STAC_VERSION } from './config';
+import { STAC_VERSION } from "./config";
 
-export const transformCatalog = (entity) => {
-    if(!entity) { return entity; }
-
-    const stacVersion = entity.stac_version || STAC_VERISON;
-    // Account for the item-assets extension renaming the property used
-    // in collections from 'assets' to 'item-assets' for STAC 1.0
-    if(entity.assets) {
-        if(stacVersion < "1.0") {
-            entity.item_assets = entity.assets;
-            delete entity.assets;
-        }
-    }
+export const transformCatalog = entity => {
+  if (!entity) {
     return entity;
+  }
+
+  const stacVersion = entity.stac_version || STAC_VERSION;
+  // Account for the item-assets extension renaming the property used
+  // in collections from 'assets' to 'item-assets' for STAC 1.0
+  if (entity.assets) {
+    if (stacVersion < "1.0") {
+      entity.item_assets = entity.assets;
+      delete entity.assets;
+    }
+  }
+  return entity;
 };
 
-export const transformItem = (entity) => {
-    return entity;
+export const transformItem = entity => {
+  return entity;
 };


### PR DESCRIPTION
This PR adds support for external pagination through links with relation `first`, `previous`, `next` and `last`
Whenever one of those links is present (usually only `next` is present on the first "page"), the auto pagination from Bootstrap Vue is hidden, and a custom one is shown without page number (as we can't tell how many pages we have if the external pagination uses a cursor instead of pages)

I also enforced the `limit` URL param with the constant `ITEMS_PER_PAGE`, I thought it made more sense. Before this implementation, our dataset was requested without limit, and we have chosen to give 100 items by default. The auto pagination was all broken because it added 4 pages (25 items per page), but the click on a page nav was triggering a request with a `page={currentPageNumber}` which was not supported, rendering us unable to see the items 26 to 100. With this limit enforced, this should not happen anymore (if there is no external pagination, but the default payload size does not match 25)

Is this limit of 25 items per page in the STAC API? I haven't found anything about it.

Some improvements that could be made (but our backend doesn't support those value yet so I couldn't really implement/test them) :

- Check if the catalog has a `numberReturned` containing how many items there is, and extrapolate page number with that (we could go back to the Vue Bootstrap component this way)

I haven't seen any Unit or E2E tests in the project, so I don't know at what extent I could have broken stuff. Please tell me right away if what I've done is not good enough.

You can see my PR in action [here](https://stac-browser.lepak.ch/)

This fulfill https://github.com/radiantearth/stac-browser/issues/34