### PR TITLE
Allow for query parameters already present in the items URL

### DIFF
--- a/src/components/Catalog.vue
+++ b/src/components/Catalog.vue
@@ -373,7 +373,7 @@ export default {
         }
 
         try {
-          let sep = `${externalItemsLink.href}`.match(/\?/) ? '&' : '?';
+          let sep = externalItemsLink.href.includes('?') ? '&' : '?';
           const rsp = await fetchUri(
             `${externalItemsLink.href}${sep}page=${this.currentItemPage}`
           );

--- a/src/components/Catalog.vue
+++ b/src/components/Catalog.vue
@@ -373,8 +373,9 @@ export default {
         }
 
         try {
+          let sep = `${externalItemsLink.href}`.match(/\?/) ? '&' : '?';
           const rsp = await fetchUri(
-            `${externalItemsLink.href}?page=${this.currentItemPage}`
+            `${externalItemsLink.href}${sep}page=${this.currentItemPage}`
           );
 
           if (!rsp.ok) {
@@ -404,7 +405,7 @@ export default {
           return items.features.map((item, idx) => ({
             item,
             to: `/item${p}/${this.slugify(
-              `${externalItemsLink.href}?page=${this.currentItemPage}#${idx}`
+              `${externalItemsLink.href}${sep}page=${this.currentItemPage}#${idx}`
             )}`,
             title: item.properties.title || item.id,
             dateAcquired: item.properties.datetime


### PR DESCRIPTION
Some users may wish to provide a URL to items containing
query parameters, for instance an authentification token.
This modification allows to add page parameters without breaking
the existing parameters.