### PR TITLE
hacked in wms example - first cut

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,5 +1,5 @@
 module.exports = {
-    catalogUrl: "http://asc-moon.s3-us-west-2.amazonaws.com/kaguyatc_dtms/collection.json",
+    catalogUrl: null,
     catalogTitle: "STAC Browser",
     allowExternalAccess: true, // Must be true if catalogUrl is not given
     tileSourceTemplate: "https://tiles.rdnt.io/tiles/{z}/{x}/{y}@2x?url={ASSET_HREF}",

--- a/config.js
+++ b/config.js
@@ -1,6 +1,6 @@
 module.exports = {
-    catalogUrl: "https://raw.githubusercontent.com/cholmes/pdd-stac/beta2/disasters/collection.json",
-    catalogTitle: "STAC Browser",
+    catalogUrl: "http://asc-moon.s3-us-west-2.amazonaws.com/kaguyatc_dtms/collection.json",
+    catalogTitle: "dev STAC browser",
     tileSourceTemplate: "https://tiles.rdnt.io/tiles/{z}/{x}/{y}@2x?url={ASSET_HREF}",
     stacProxyUrl: null,
     tileProxyUrl: null,

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -2,7 +2,15 @@
   <section class="mb-4">
     <l-map class="map" :class="stac.type" ref="leaflet" @ready="init()">
       <l-control-fullscreen />
-      <l-tile-layer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" :options="mapOptions" />
+      <l-wms-tile-layer
+          :key="getBaseMap.name"
+          :base-url="getBaseMap.baseUrl"
+          :crs="getBaseMap.crs"
+          :name="getBaseMap.name"
+          :attribution="getBaseMap.attribution"
+          :layers="getBaseMap.name"
+          :format="getBaseMap.format"
+          layer-type="base"/>
       <!-- ToDo: Replace with STAC Leaflet plugin; use minimap plugin? -->
       <l-geo-json v-if="isGeoJSON" ref="bounds" @ready="fitBounds" :geojson="stac" />
       <l-rectangle v-else-if="bbox" ref="bounds" @ready="fitBounds" :bounds="bbox" />
@@ -12,7 +20,8 @@
 
 <script>
 // import L from 'leaflet';
-import { LMap, LGeoJson, LRectangle, LTileLayer } from 'vue2-leaflet';
+import { CRS } from "leaflet";
+import { LMap, LGeoJson, LRectangle, LWMSTileLayer } from 'vue2-leaflet';
 import LControlFullscreen from 'vue2-leaflet-fullscreen';
 import 'leaflet/dist/leaflet.css';
 
@@ -23,15 +32,12 @@ export default {
     LGeoJson,
     LMap,
     LRectangle,
-    LTileLayer
+    'l-wms-tile-layer': LWMSTileLayer
   },
   data() {
     return {
       map: null,
-      boundsLayer: null,
-      mapOptions: {
-        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a> contributors.'
-      }
+      boundsLayer: null
     };
   },
   props: {
@@ -50,7 +56,36 @@ export default {
         return [[bbox[1], bbox[2]], [bbox[3], bbox[0]]];
       }
       return null;
-    }
+    },
+    getBaseMap() {
+      if ('summaries' in this.stac) {
+        if ('ssys:targets' in this.stac.summaries){
+          var target = this.stac.summaries['ssys:targets'][0]
+          switch (target.normalize()) {
+            case "moon":
+                return {"name":"LROC_WAC",
+                    "baseUrl":"https://planetarymaps.usgs.gov/cgi-bin/mapserv?map=/maps/earth/moon_simp_cyl.map",
+                    "crs":CRS.EPSG4326,
+                    "attribution":"USGS Astrogeology",
+                    "format":"image/png"
+                    }
+          }
+
+        }
+      }
+      // Our items still need the ssys:targets implemented, so this just hard codes to the moon for now. Will
+      // check for ssys:targets in properties at some point in the future.
+      if ('properties' in this.stac) {
+          return {"name":"LROC_WAC",
+                  "baseUrl":"https://planetarymaps.usgs.gov/cgi-bin/mapserv?map=/maps/earth/moon_simp_cyl.map",
+                  "crs":CRS.EPSG4326,
+                  "attribution":"USGS Astrogeology",
+                  "format":"image/png"
+                  }
+        
+      }
+    return {}
+    }        
   },
   methods: {
     init() {
@@ -63,3 +98,4 @@ export default {
   }
 }
 </script>
+

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -1,32 +1,24 @@
 <template>
   <section class="mb-4">
     <l-map class="map" :class="stac.type" ref="leaflet" @ready="init()">
-      <l-control-fullscreen />
-      <l-wms-tile-layer v-if="hasSsys"
-          :key="baseMap.name"
-          :base-url="baseMap.baseUrl"
-          :crs="baseMap.crs"
-          :name="baseMap.name"
-          :attribution="baseMap.attribution"
-          :layers="baseMap.name"
-          :format="baseMap.format"
-          layer-type="base"
-          @ready="fitBounds" :bounds="bbox"/>
-      <l-tile-layer v-else url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" :options="mapOptions" />
-
+      <LControlFullscreen />
+      <template v-if="baseMaps.length > 0">
+        <component :is="baseMap.component" v-for="baseMap in baseMaps" :key="baseMap.name" v-bind="baseMap" :layers="baseMap.name" layer-type="base" />
+      </template>
+      <LTileLayer v-else url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" :options="mapOptions" />
       <!-- ToDo: Replace with STAC Leaflet plugin; use minimap plugin? -->
-      <l-geo-json v-if="isGeoJSON" ref="bounds" @ready="fitBounds" :geojson="stac" />
-      <l-rectangle v-else-if="bbox" ref="bounds" @ready="fitBounds" :bounds="bbox" />
+      <LGeoJson v-if="isGeoJSON" ref="bounds" @ready="fitBounds" :geojson="stac" />
+      <LRectangle v-else-if="bbox" ref="bounds" @ready="fitBounds" :bounds="bbox" />
     </l-map>
   </section>
 </template>
 
 <script>
-// import L from 'leaflet';
 import { CRS } from "leaflet";
 import { LMap, LGeoJson, LRectangle, LTileLayer, LWMSTileLayer } from 'vue2-leaflet';
 import LControlFullscreen from 'vue2-leaflet-fullscreen';
 import 'leaflet/dist/leaflet.css';
+import Utils from '../utils';
 
 export default {
   name: 'Map',
@@ -36,7 +28,7 @@ export default {
     LMap,
     LRectangle,
     LTileLayer,
-    "l-wms-tile-layer" : LWMSTileLayer
+    LWMSTileLayer
   },
   data() {
     return {
@@ -64,35 +56,45 @@ export default {
       }
       return null;
     },
-    hasSsys() {
-      if ('summaries' in this.stac) {
-        if ('ssys:targets' in this.stac.summaries){
-          return true
+    baseMaps() {
+      let targets = [];
+      if (this.stac.isCollection() && Utils.isObject(this.stac.summaries) && Array.isArray(this.stac.summaries['ssys:targets'])) {
+        targets = this.stac.summaries['ssys:targets'];
+      }
+      else if (this.stac.isCollection() && Array.isArray(this.stac['ssys:targets'])) {
+        targets = this.stac['ssys:targets'];
+      }
+      else if (this.stac.isItem() && Array.isArray(this.stac.properties['ssys:targets'])) {
+        targets = this.stac.properties['ssys:targets'];
+      }
+
+      const baseMaps = {
+        europa: {
+          baseUrl: "https://planetarymaps.usgs.gov/cgi-bin/mapserv?map=/maps/jupiter/europa_simp_cyl.map",
+          name: "GALILEO_VOYAGER"
+        },
+        mars: {
+          baseUrl: "https://planetarymaps.usgs.gov/cgi-bin/mapserv?map=/maps/mars/mars_simp_cyl.map",
+          name: "MDIM21"
+        },
+        moon: {
+          baseUrl: "https://planetarymaps.usgs.gov/cgi-bin/mapserv?map=/maps/earth/moon_simp_cyl.map",
+          name: "LROC_WAC"
         }
-      } else if ('ssys:targets' in this.stac.properties) {
-        return true
-      }
-      return false
-    },
-    baseMap() {
-      var target = ''
-      if ('summaries' in this.stac){
-        target = this.stac.summaries['ssys:targets'][0].toLowerCase()
-      } else if ('properties' in this.stac){
-        target = this.stac.properties['ssys:targets'][0].toLowerCase()
-      }
-      var baseLookUp = {
-            "europa": {"url":"/maps/jupiter/europa_simp_cyl.map", "name":"GALILEO_VOYAGER"},
-            "mars": {"url": "/maps/mars/mars_simp_cyl.map", "name":"MDIM21"},
-            "moon": {"url": "/maps/earth/moon_simp_cyl.map", "name":"LROC_WAC"},
-          }
-      return { "name": baseLookUp[target].name,
-                "baseUrl": "https://planetarymaps.usgs.gov/cgi-bin/mapserv?map=" + baseLookUp[target].url,
-                "crs":CRS.EPSG4326,
-                "attribution":"USGS Astrogeology",
-                "format":"image/png"
-              }
-        }     
+      };
+
+      return targets.map(target => {
+        target = target.toLowerCase();
+        if (baseMaps[target]) {
+          return Object.assign({
+              component: "LWMSTileLayer",
+              crs: CRS.EPSG4326,
+              attribution: "USGS Astrogeology",
+              format: "image/png"
+            }, baseMaps[target]);
+        }
+      });
+    }        
   },
   methods: {
     init() {


### PR DESCRIPTION
This is an example of how to get a WMS planetary base into STAC browser. Lots of issues still exist, so this PR is just trying to get a conversation rolling with the maintainers. I am leaving vue as I do this, so the implementation is very janky.

Things that I would love feedback on:

1. Leaflet makes a distinction between a tiled layer and a wms layer. I had to remove the tiled layer to be able to get the wms layer in. Is it possible to define an either/or in the template based on something computed in the script? (e.g., if ssys:targets[0] === "moon", use WMS, else, use the openstreetmap tiles.
2. I have broached the subject of use serving these bases as tiled maps too, so if this is a non-starter, we might be able to adjust the data source
2. The WMS parameters are getting passed using the getBaseMap function - the way it is written, am I calling that function over and over? If so, what is the proper way to do this?
3. The getBaseMap function is going to end up with a lot of cases in the switch - is that okay? Is this the place to code that?
4. The items are hard coded right now because the item.json files do not implement the syss extension. They are hard coded to show the moon though. When I select an item the first time, the rendering is good (WMS base, centered polygon bbox). When I select a different item, it looks like something is being cached(?) as the zoom is quite wrong. Is that also happening if you test this?

Much appreciate the feedback. I am excited to see this developing, the addition of search, etc. Good inspiration to get my vue/javascript chops up to be able to participate!