### PR TITLE
Allow crossorigin images

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "core-js": "^3.6.5",
     "leaflet": "^1.7.1",
     "remove-markdown": "^0.3.0",
-    "stac-layer": "^0.7.1",
+    "stac-layer": "^0.8.0",
     "urijs": "^1.19.6",
     "v-clipboard": "^2.2.3",
     "vue": "^2.6.12",

--- a/src/components/Catalog.vue
+++ b/src/components/Catalog.vue
@@ -1,6 +1,6 @@
 <template>
   <b-card no-body class="catalog-card" :class="{queued: !this.data}" v-b-visible.200="load">
-    <b-card-img v-if="thumbnail && showThumbnail" class="thumbnail" :src="thumbnail.href" :alt="thumbnail.title" fluid></b-card-img>
+    <b-card-img v-if="thumbnail && showThumbnail" class="thumbnail" :src="thumbnail.href" :alt="thumbnail.title" crossorigin="anonymous" fluid></b-card-img>
     <b-card-body>
       <b-card-title>
         <StacLink :link="catalog" :title="title" class="stretched-link" />

--- a/src/components/Item.vue
+++ b/src/components/Item.vue
@@ -1,6 +1,6 @@
 <template>
   <b-card no-body class="item-card" :class="{queued: !this.data}" v-bind="cardProps" v-b-visible.200="load">
-    <b-card-img v-if="thumbnail && showThumbnail" class="thumbnail" :src="thumbnail.href" :alt="thumbnail.title" fluid></b-card-img>
+    <b-card-img v-if="thumbnail && showThumbnail" class="thumbnail" :src="thumbnail.href" :alt="thumbnail.title" crossorigin="anonymous" fluid></b-card-img>
     <b-card-body>
       <b-card-title>
         <StacLink :link="item" :title="title" class="stretched-link" />

--- a/src/components/Thumbnails.vue
+++ b/src/components/Thumbnails.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="previews">
     <a v-for="thumbnail in thumbnails" :key="thumbnail.href" :href="thumbnail.href">
-      <img class="thumbnail" :src="thumbnail.href" />
+      <img class="thumbnail" :src="thumbnail.href" crossorigin="anonymous" />
     </a>
   </div>
 </template>


### PR DESCRIPTION
Currently loading a cross-origin image fails to display on the map. There is a new version of stac-layer to send image request with `crossOrigin: "anonymous"`. See https://github.com/DanielJDufour/easy-image-loader/pull/1 and https://github.com/stac-utils/stac-layer/commit/8d23872b7c70ce24e8d4df47ddd3fc01aa4501c3

Also, if the image has a server-side origin restriction, it requires to be loaded with `crossorigin="anonymous"` even in `img` tags, so that `Origin` header is sent.