### PR TITLE
Collection items map

### DIFF
--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -138,14 +138,14 @@ export default {
     async showStacLayer() {
       if (this.stacLayer) {
         try {
-          this.map.removeLayer(this.stacLayer)
+          this.map.removeLayer(this.stacLayer);
         } catch (e) {
-          console.log(e)
+          console.log(e);
         }
         this.stacLayer = null;
       } 
       if (this.boundsLayer) {
-        this.map.removeLayer(this.boundsLayer)
+        this.map.removeLayer(this.boundsLayer);
         this.boundsLayer = null;
       }
       let data = this.stacLayerData || this.stac;
@@ -169,12 +169,12 @@ export default {
         }
       }
       if (this.stac.type === 'Collection' && Array.isArray(this.stac?.extent?.spatial?.bbox[0])) {
-        const bounds = this.stac.extent.spatial.bbox[0]
+        const bounds = this.stac.extent.spatial.bbox[0];
         this.boundsLayer = rectangle([[bounds[1], bounds[0]], [bounds[3], bounds[2]]], {
           fillOpacity: 0.1,
           weight: 1
-        }).addTo(this.map)
-        options.displayPreview = true
+        }).addTo(this.map);
+        options.displayPreview = true;
       }
 
       try {

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -19,7 +19,7 @@ import { mapState } from 'vuex';
 import STAC from '../stac';
 
 // Fix missing icons: https://vue2-leaflet.netlify.app/quickstart/#marker-icons-are-missing
-import { Icon } from 'leaflet';
+import { Icon, rectangle } from 'leaflet';
 delete Icon.Default.prototype._getIconUrl;
 Icon.Default.mergeOptions({
   iconRetinaUrl: require('leaflet/dist/images/marker-icon-2x.png'),
@@ -42,6 +42,7 @@ export default {
       map: null,
       areaSelect: null,
       stacLayer: null,
+      boundsLayer: null,
       mapOptions: {},
       osmOptions: {
         attribution: '&copy; <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a> contributors.'
@@ -138,6 +139,10 @@ export default {
       if (this.stacLayer) {
         this.map.removeLayer(this.stacLayer);
         this.stacLayer = null;
+      } 
+      if (this.boundsLayer) {
+        this.map.removeLayer(this.boundsLayer)
+        this.boundsLayer = null;
       }
       let data = this.stacLayerData || this.stac;
 
@@ -159,6 +164,14 @@ export default {
           options.bbox = this.stac?.extent?.spatial?.bbox[0];
         }
       }
+      if (this.stac.type === 'Collection' && Array.isArray(this.stac?.extent?.spatial?.bbox[0])) {
+        const bounds = this.stac.extent.spatial.bbox[0]
+        this.boundsLayer = rectangle([[bounds[1], bounds[0]], [bounds[3], bounds[2]]], {
+          fillOpacity: 0.1,
+          weight: 1
+        }).addTo(this.map)
+      }
+
       try {
         this.stacLayer = await stacLayer(data, options);
       } catch (error) {

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -137,7 +137,11 @@ export default {
     },
     async showStacLayer() {
       if (this.stacLayer) {
-        this.map.removeLayer(this.stacLayer);
+        try {
+          this.map.removeLayer(this.stacLayer)
+        } catch (e) {
+          console.log(e)
+        }
         this.stacLayer = null;
       } 
       if (this.boundsLayer) {
@@ -170,6 +174,7 @@ export default {
           fillOpacity: 0.1,
           weight: 1
         }).addTo(this.map)
+        options.displayPreview = true
       }
 
       try {

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -164,15 +164,20 @@ export default {
         if (this.stac.type === 'Feature') {
           options.bbox = this.stac?.bbox;
         }
-        else if (this.stac.type === 'Collection') {
-          options.bbox = this.stac?.extent?.spatial?.bbox[0];
-        }
       }
       if (this.stac.type === 'Collection' && Array.isArray(this.stac?.extent?.spatial?.bbox[0])) {
-        const bounds = this.stac.extent.spatial.bbox[0];
+        const bounds = [Infinity, Infinity, -Infinity, -Infinity];
+        this.stac.extent.spatial.bbox.forEach((bbox) => {
+          if (bbox[0] < bounds[0]) bounds[0] = bbox[0];
+          if (bbox[1] < bounds[1]) bounds[1] = bbox[1];
+          if (bbox[2] > bounds[2]) bounds[2] = bbox[2];
+          if (bbox[3] > bounds[3]) bounds[3] = bbox[3];
+        });
+        options.bbox = bounds;
         this.boundsLayer = rectangle([[bounds[1], bounds[0]], [bounds[3], bounds[2]]], {
-          fillOpacity: 0.1,
-          weight: 1
+          fillOpacity: 0,
+          weight: 1,
+          color: '#17a2b8'
         }).addTo(this.map);
         options.displayPreview = true;
       }

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -214,7 +214,8 @@ export default {
         animate: false,
         duration: 0
       };
-      this.map.fitBounds(this.stacLayer.getBounds(), fitOptions);
+      const bounds = this.boundsLayer !== null ? this.boundsLayer.getBounds() : this.stacLayer.getBounds();
+      this.map.fitBounds(bounds, fitOptions);
     },
     addBoundsSelector() {
       this.areaSelect = L.areaSelect({ // eslint-disable-line 

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -140,56 +140,55 @@ export default {
         this.stacLayer = null;
       }
       let data = this.stacLayerData || this.stac;
-      if (data.type !== 'Catalog') {
-        let options = {
-          resolution: this.geoTiffResolution,
-          useTileLayerAsFallback: this.useTileLayerAsFallback,
-          tileUrlTemplate: this.tileSourceTemplate,
-          buildTileUrlTemplate: this.buildTileUrlTemplate,
-          crossOrigin: this.crossOriginMedia
-        };
-        if (this.stac instanceof STAC) {
-          options.baseUrl = this.stac.getAbsoluteUrl();
-        }
-        if ('href' in data) {
-          if (this.stac.type === 'Feature') {
-            options.bbox = this.stac?.bbox;
-          }
-          else if (this.stac.type === 'Collection') {
-            options.bbox = this.stac?.extent?.spatial?.bbox[0];
-          }
-        }
-        try {
-          this.stacLayer = await stacLayer(data, options);
-        } catch (error) {
-          this.$root.$emit('error', error, 'Sorry, adding the data to the map failed.');
-        }
 
-        // If the map isn't shown any more after loading the STAC data, don't try to add it to the map.
-        // Fixes https://github.com/radiantearth/stac-browser/issues/109
-        if (!this.show || !this.stacLayer) {
-          return;
-        }
-
-        this.$emit('mapChanged', this.stacLayer.stac);
-        this.stacLayer.on('click', event => {
-          // Debounce click event, otherwise a dblclick is fired (and fired twice)
-          let clicks = event.originalEvent.detail || 1;
-          if (clicks === 1) {
-            this.dblClickState = window.setTimeout(() => {
-              this.dblClickState = null;
-              this.$emit('mapClicked', event.stac);
-            }, 500);
-          }
-          else if (clicks > 1 && this.dblClickState) {
-            window.clearTimeout(this.dblClickState);
-            this.dblClickState = null;
-          }
-        });
-        this.stacLayer.on("fallback", event => this.$emit('mapChanged', event.stac));
-        this.stacLayer.addTo(this.map);
-        this.fitBounds();
+      let options = {
+        resolution: this.geoTiffResolution,
+        useTileLayerAsFallback: this.useTileLayerAsFallback,
+        tileUrlTemplate: this.tileSourceTemplate,
+        buildTileUrlTemplate: this.buildTileUrlTemplate,
+        crossOrigin: this.crossOriginMedia
+      };
+      if (this.stac instanceof STAC) {
+        options.baseUrl = this.stac.getAbsoluteUrl();
       }
+      if ('href' in data) {
+        if (this.stac.type === 'Feature') {
+          options.bbox = this.stac?.bbox;
+        }
+        else if (this.stac.type === 'Collection') {
+          options.bbox = this.stac?.extent?.spatial?.bbox[0];
+        }
+      }
+      try {
+        this.stacLayer = await stacLayer(data, options);
+      } catch (error) {
+        this.$root.$emit('error', error, 'Sorry, adding the data to the map failed.');
+      }
+
+      // If the map isn't shown any more after loading the STAC data, don't try to add it to the map.
+      // Fixes https://github.com/radiantearth/stac-browser/issues/109
+      if (!this.show || !this.stacLayer) {
+        return;
+      }
+
+      this.$emit('mapChanged', this.stacLayer.stac);
+      this.stacLayer.on('click', event => {
+        // Debounce click event, otherwise a dblclick is fired (and fired twice)
+        let clicks = event.originalEvent.detail || 1;
+        if (clicks === 1) {
+          this.dblClickState = window.setTimeout(() => {
+            this.dblClickState = null;
+            this.$emit('mapClicked', event.stac);
+          }, 500);
+        }
+        else if (clicks > 1 && this.dblClickState) {
+          window.clearTimeout(this.dblClickState);
+          this.dblClickState = null;
+        }
+      });
+      this.stacLayer.on("fallback", event => this.$emit('mapChanged', event.stac));
+      this.stacLayer.addTo(this.map);
+      this.fitBounds();
     },
     fitBounds() {
       let fitOptions = {

--- a/src/stac.js
+++ b/src/stac.js
@@ -8,6 +8,7 @@ class STAC {
 
     constructor(data, url, path, migrate = true) {
         this._id = stacObjCounter++;
+        this._rawJson = data
         this._url = url;
         this._path = path;
         this._apiChildren = {

--- a/src/stac.js
+++ b/src/stac.js
@@ -8,7 +8,6 @@ class STAC {
 
     constructor(data, url, path, migrate = true) {
         this._id = stacObjCounter++;
-        this._rawJson = data
         this._url = url;
         this._path = path;
         this._apiChildren = {

--- a/src/views/Catalog.vue
+++ b/src/views/Catalog.vue
@@ -160,7 +160,7 @@ export default {
     catalogAsFc () {
       return {
         type: 'FeatureCollection',
-        features: this.items
+        features: this.items.map(i => i._rawJson)
       }
     }
   },

--- a/src/views/Catalog.vue
+++ b/src/views/Catalog.vue
@@ -25,7 +25,7 @@
           <b-card no-body class="maps-preview">
             <b-tabs v-model="tab" ref="tabs" pills card vertical end>
               <b-tab v-if="isCollection" title="Map" no-body>
-                <Map :stac="data" :stacLayerData="selectedAsset" @mapClicked="mapClicked" @mapChanged="mapChanged" />
+                <Map :stac="data" :stacLayerData="catalogAsFc" @mapClicked="mapClicked" @mapChanged="mapChanged" />
               </b-tab>
               <b-tab v-if="thumbnails.length > 0" title="Preview" no-body>
                 <Thumbnails :thumbnails="thumbnails" />
@@ -156,6 +156,13 @@ export default {
     },
     hasCatalogs() {
       return this.catalogs.length > 0;
+    },
+    catalogAsFc () {
+      return {
+        type: 'FeatureCollection',
+        bbox: this.data.extent.spatial.bbox[0],
+        features: this.items
+      }
     }
   },
   methods: {

--- a/src/views/Catalog.vue
+++ b/src/views/Catalog.vue
@@ -163,8 +163,8 @@ export default {
     catalogAsFc () {
       return {
         type: 'FeatureCollection',
-        features: this.items.map(i => i._rawJson)
-      }
+        features: this.items
+      };
     }
   },
   methods: {

--- a/src/views/Catalog.vue
+++ b/src/views/Catalog.vue
@@ -160,7 +160,6 @@ export default {
     catalogAsFc () {
       return {
         type: 'FeatureCollection',
-        bbox: this.data.extent.spatial.bbox[0],
         features: this.items
       }
     }


### PR DESCRIPTION
This PR adds support for viewing Collection Item extents on the preview map. And when [this PR](https://github.com/stac-utils/stac-layer/pull/34) get's merged in `stac-layer` it'll also show the thumbnail or overview for each item on the map.

In theory the extents and thumbnails update when the user uses the pagination, although there does seem to be some sort of bug in removing the old items when a user pages, I think this is coming from upstream in georaster-for-leaflet, so I'm currently tracking that down.

https://user-images.githubusercontent.com/6735870/163709004-732f50ef-7ec1-40a0-8349-83ad3de9bd95.mp4

I suggest we keep this in draft until I can work out what's going on upstream.
