### PR TITLE
App state in URL

### DIFF
--- a/src/StacBrowser.vue
+++ b/src/StacBrowser.vue
@@ -185,6 +185,8 @@ export default {
           query
         });
       }
+      this.$store.commit('setAppStateFromQueryStringObject', query);
+
     },
     showError(error, message) {
       this.$store.commit('showGlobalError', {

--- a/src/components/Asset.vue
+++ b/src/components/Asset.vue
@@ -19,7 +19,7 @@
         </div>
       </b-button>
     </b-card-header>
-    <b-collapse :id="uid" v-model="expanded" accordion="assets" role="tabpanel">
+    <b-collapse :id="uid" v-model="expanded" accordion="assets" role="tabpanel" @input="collapseToggled">
       <b-card-body>
         <b-card-title>{{ fileFormat }}</b-card-title>
         <b-button-group class="actions" v-if="href">
@@ -240,9 +240,18 @@ export default {
         text.push(this.from);
       }
       return text.join(' ');
+    },
+    openAssetsUids () {
+      return this.$store.state.appState.openAssetsUids;
     }
   },
   created() {
+
+    if (this.openAssetsUids.indexOf(this.uid) > -1) {
+      this.expanded = true;
+      return;
+    }
+
     if (typeof this.expand === 'boolean') {
       this.expanded = this.expand;
     }
@@ -279,6 +288,13 @@ export default {
           return 'local file system';
       }
       return '';
+    },
+    collapseToggled (isVisible) {
+      if (isVisible) {
+        this.$store.commit('addUidToOpenAssets', this.uid);
+      } else {
+        this.$store.commit('removeUidFromOpenAssets', this.uid);
+      }
     }
   }
 };

--- a/src/components/Share.vue
+++ b/src/components/Share.vue
@@ -102,6 +102,16 @@ export default {
             let title = encodeURIComponent(this.title);
             let text = encodeURIComponent(this.message);
             return `mailto:?subject=${title}&body=${text}`;
+        },
+        appStateAsParams () {
+          var uri = new URI("?");
+          const appState = this.$store.state.appState;
+          for (const [key, value] of Object.entries(appState)) {
+            if (Array.isArray(value) && value.length > 0) {
+              uri.addSearch(key, value);
+            }
+          }
+          return uri.toString();
         }
     },
     methods: {
@@ -109,7 +119,12 @@ export default {
             await this.$store.dispatch('validate', this.stacUrl);
         },
         browserUrl() {
-            return window.location.toString();
+            let str = window.location.toString();
+            const querystring = this.appStateAsParams;
+            if (querystring !== '?') {
+              str += querystring;
+            }
+            return str;
         }
     }
 };

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -62,7 +62,10 @@ function getStore(config) {
         'root',
         'search',
         'self',
-      ]
+      ],
+      appState: {
+        openAssetsUids: []
+      }
     }),
     getters: {
       loading: state => !state.url || !state.data || state.database[state.url] instanceof Loading,
@@ -331,6 +334,28 @@ function getStore(config) {
       queryParameters(state, params) {
         for(let key in params) {
           state[`${key}QueryParameters`] = params[key];
+        }
+      },
+      setAppStateFromQueryStringObject (state, queryObject) {
+        const appState = state.appState;
+        for (const [key, value] of Object.entries(queryObject)) {
+          if (Array.isArray(appState[key])) {
+            const values = value.split(',');
+            state.appState[key].push(...values);
+          }
+        }
+      },
+      addUidToOpenAssets (state, uid) {
+        const idx = state.appState.openAssetsUids.indexOf(uid);
+        // need to revent duplicates because of the way the collapse v-model works
+        if (idx === -1) {
+          state.appState.openAssetsUids.push(uid);
+        }
+      },
+      removeUidFromOpenAssets (state, uid) {
+        const idx = state.appState.openAssetsUids.indexOf(uid);
+        if (idx > -1) {
+          state.appState.openAssetsUids.splice(idx, 1);
         }
       },
       stacIndex(state, index) {


### PR DESCRIPTION
This PR contains some initial work to store app state in the store, then use that state when constructing share urls, and apply the state from the url when opening a link.

I've used the example of asset collapses.

https://user-images.githubusercontent.com/6735870/177087634-a817be2c-10dc-4586-9489-5ebe6aa16c1f.mp4

I probably need to add something to clean out the app state on each page navigation but that should be straight forward.

What do you think of this approach @m-mohr ?
