### PR TITLE
Pagination state

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "bs58": "^4.0.1",
     "commonmark": "^0.29.3",
     "core-js": "^3.6.5",
+    "is-json": "^2.0.1",
     "leaflet": "^1.8.0",
     "node-polyfill-webpack-plugin": "^2.0.0",
     "remove-markdown": "^0.3.0",

--- a/src/StacBrowser.vue
+++ b/src/StacBrowser.vue
@@ -117,20 +117,11 @@ export default {
     };
   },
   computed: {
-    ...mapState(['title', 'globalError', 'stateQueryParameters']),
+    ...mapState(['title', 'globalError', 'stateQueryParameters', 'apiItemsLink']),
     ...mapState({catalogUrlFromVueX: 'catalogUrl'}),
-    ...mapGetters(['displayCatalogTitle']),
+    ...mapGetters(['displayCatalogTitle', 'appStateAsParams']),
     browserVersion() {
       return STAC_BROWSER_VERSION;
-    },
-    appStateAsParams () {
-      const out = {};
-      for (const [key, value] of Object.entries(this.$store.state.stateQueryParameters)) {
-        if (Array.isArray(value) && value.length > 0) {
-          out[`.${key}`] = value;
-        }
-      }
-      return out;
     }
   },
   watch: {

--- a/src/StacBrowser.vue
+++ b/src/StacBrowser.vue
@@ -117,7 +117,7 @@ export default {
     };
   },
   computed: {
-    ...mapState(['title', 'globalError', 'stateQueryParameters', 'apiItemsLink']),
+    ...mapState(['title', 'globalError', 'stateQueryParameters']),
     ...mapState({catalogUrlFromVueX: 'catalogUrl'}),
     ...mapGetters(['displayCatalogTitle', 'appStateAsParams']),
     browserVersion() {

--- a/src/StacBrowser.vue
+++ b/src/StacBrowser.vue
@@ -46,6 +46,7 @@ import StacHeader from './components/StacHeader.vue';
 import Utils from './utils';
 import URI from 'urijs';
 
+
 const CONFIG_FILE = require(CONFIG_PATH);
 
 Vue.use(Clipboard);

--- a/src/components/Items.vue
+++ b/src/components/Items.vue
@@ -43,7 +43,6 @@ import { BCollapse, BIconSearch } from "bootstrap-vue";
 import Utils from '../utils';
 import STAC from '../models/stac';
 import sortCapabilitiesMixinGenerator from './SortCapabilitiesMixin';
-import URI from 'urijs'
 
 export default {
   name: "Items",
@@ -139,6 +138,13 @@ export default {
   methods: {
     emitFilter(value, reset) {
       this.$emit('filterItems', value, reset);
+      if (Object.keys(this.$store.state.stateQueryParameters.itemsPage).length > 0) {
+        this.$store.commit('queryParameters', {
+          state: {
+            itemsPage: {}
+          }
+        });        
+      }
     },
     showMore() {
       this.shownItems += this.chunkSize;
@@ -148,12 +154,10 @@ export default {
         Utils.scrollTo(this.$refs.topPagination.$el);
       }
       this.$emit('paginate', link);
-      const uri = new URI(link.href);
-      const params = uri.search(true);
+
       this.$store.commit('queryParameters', {
         state: {
-          itemsToken: params.token,
-          numItems: params.limit
+          itemsPage: link
         }
       });
     }

--- a/src/components/Items.vue
+++ b/src/components/Items.vue
@@ -155,9 +155,16 @@ export default {
       }
       this.$emit('paginate', link);
 
+      let compactPageRef = {};
+      if (!('method' in link) || link.method === 'GET') {
+        compactPageRef = {
+          href: link.href.split('?')[1]
+        };
+      }
+
       this.$store.commit('queryParameters', {
         state: {
-          itemsPage: link
+          itemsPage: compactPageRef
         }
       });
     }

--- a/src/components/Items.vue
+++ b/src/components/Items.vue
@@ -43,6 +43,7 @@ import { BCollapse, BIconSearch } from "bootstrap-vue";
 import Utils from '../utils';
 import STAC from '../models/stac';
 import sortCapabilitiesMixinGenerator from './SortCapabilitiesMixin';
+import URI from 'urijs'
 
 export default {
   name: "Items",
@@ -147,6 +148,14 @@ export default {
         Utils.scrollTo(this.$refs.topPagination.$el);
       }
       this.$emit('paginate', link);
+      const uri = new URI(link.href);
+      const params = uri.search(true);
+      this.$store.commit('queryParameters', {
+        state: {
+          itemsToken: params.token,
+          numItems: params.limit
+        }
+      });
     }
   }
 };

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -669,12 +669,7 @@ function getStore(config) {
               token: cx.state.stateQueryParameters.itemsToken,
               limit: cx.state.stateQueryParameters.numItems
             });
-
-            link = {
-              href: uri.toString(),
-              method: 'GET',
-              type: 'application/geo+json'
-            };
+            link.href = uri.toString();
           }
 
           if (!Utils.isObject(filters)) {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -673,7 +673,7 @@ function getStore(config) {
             Object.keys(cx.state.stateQueryParameters.itemsPage).length > 0 &&
             linkWasUndefined
           ) {
-              link = cx.state.stateQueryParameters.itemsPage;
+              link.href = `${link.href}?${cx.state.stateQueryParameters.itemsPage.href}`;
           }
 
           if (!Utils.isObject(filters)) {


### PR DESCRIPTION
This PR adds support for sharing links with the pagination state, for example if you are on page 2 of a set of collection items and share the link the user will open to page 2 of the results.

I wouldn't say I'm overly happy with where the logic is placed in the store because in many regards this code should only run once when the app loads but I found it difficult to move the code anywhere else.

Still need to test what happens on static catalogs.