### PR TITLE
Encode asset URIs

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -23,6 +23,6 @@ const getTileProxiedUri = (uri) => {
 }
 
 export const getTileSource = (assetHref) => {
-  const proxiedUri = getTileProxiedUri(assetHref);
+  const proxiedUri = encodeURIComponent(getTileProxiedUri(assetHref));
   return TILE_SOURCE_TEMPLATE.replace("{ASSET_HREF}", proxiedUri);
 }


### PR DESCRIPTION
NB: This is the simplest possible version of this PR, to see if it's valuable before fleshing it out.

## Scenario
Using `stac-fastapi` running at `:8000` for the STAC API, and `TiTiler` at `:8001` for the tiler.
Running `stac-browser` as follows:
```bash
npm start -- --open \
    --CATALOG_URL="http://localhost:8000" \
    --TILE_SOURCE_TEMPLATE="http://localhost:8001/cog/tiles/{z}/{x}/{y}?url={ASSET_HREF}"
```
## Problem
Currently, `stac-browser` calls the tiler as follows:
```
:8001/cog/tiles?url=https://blob.windows.net/path/to/file.tif?par1=foo&par2=bar&par3=baz
```

Only the first `par1` makes it to the Tiler function's `url` parameter, as the rest are stripped out in the ambiguity of whether they're part of the `url` parameter, or a part of the larger URL.

## Proposal
This fix simply `encodeURIComponent`s the URI before using it. The fix works for us, though there might be non-HTTP protocols (`file`, `s3` or whatever) that don't like this? Could guard it with a check for `https://`/`http://` or put it behind a flag.