### PR TITLE
Allow relative catalog URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ Some of them can also be set [through the root catalog](#customize-through-root-
 
 The URL of the catalog to show by default.
 
+This is usually a URL provided as string, but in the config file you can also provide a function without parameters that returns the URL, e.g. `() => window.origin.toString().replace(/\/?$/, '/')`.
+
 If you don't point to a specific file make sure to append a `/` at the end of the URL as the trailing slash is significant. Without it, the last path component is considered to be a "file" name to be removed to get at the "directory" that is used as the base for resolving relative URLs. You should also make sure that your STAC files are following this rule as otherwise you may still run into issues with STAC Browser.
 
 If `catalogUrl` is empty or set to `null` STAC Browser switches to a mode where it defaults to a screen where you can either insert a catalog URL or select a catalog from [stacindex.org](https://stacindex.org).

--- a/src/config.js
+++ b/src/config.js
@@ -6,6 +6,4 @@ else {
   config = Object.assign(require(CONFIG_PATH), CONFIG_CLI);
 }
 
-config.catalogUrl = new URL(config.catalogUrl, location.href).href;
-
 export default config;

--- a/src/config.js
+++ b/src/config.js
@@ -6,4 +6,6 @@ else {
   config = Object.assign(require(CONFIG_PATH), CONFIG_CLI);
 }
 
+config.catalogUrl = new URL(config.catalogUrl, location.href).href;
+
 export default config;

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -364,7 +364,10 @@ function getStore(config, router) {
               state.catalogTitle = value;
               break;
             case 'catalogUrl':
-              if (typeof value === 'string') {
+              if (typeof value === 'function') {
+                state.catalogUrl = value();
+              }
+              else if (typeof value === 'string') {
                 state.catalogUrl = value;
               }
               break;


### PR DESCRIPTION
I'm hoping to use STAC Browser with a catalog URL that is not known until runtime.

At build time, I know the relative URL to the catalog (`/` in my case), but not the absolute URL.  When I build STAC Browser with `--catalogUrl=/`, the browser works, but all of the collection and item resources are treated as external – the browser URLs end up like `https://example.com/browser/https:/example.com/collections/my-collection`.  And because I have configured `allowExternalAccess: false`, I get a warning in the UI about external URLs not being allowed.  If I set `allowExternalAccess: true`, then `external` is inserted into the URL path.

Ideally, STAC Browser would make the `catalogUrl` absolute before checking to see whether it is "external" or not.  I'm not sure that the change I've proposed here is how you would like to handle it, but one option is to modify the config at runtime when the base URL is known, and to use the URL constructor's ability to resolve an absolute URL given a relative one.

I'm using the v3.0.0-beta.9 tag.