### PR TITLE
Add object-fit to image in order to prevent stretching

### DIFF
--- a/src/components/Catalog.vue
+++ b/src/components/Catalog.vue
@@ -144,6 +144,7 @@ export default {
         height: 100%;
         max-height: 8.5rem;
         max-width: 33%;
+        object-fit: cover;
       }
 
       .intro {


### PR DESCRIPTION
This PR adds `object-fit: cover` to images displayed in list view, in order to cover the available space and not stretch them. I considered using `contain` instead of `cover`, but it would mess up the intended layout. A user could still modify this via custom css, but I think `cover` is a good default setting.

Before:
![image](https://user-images.githubusercontent.com/26576876/237022565-6c924195-2c9e-48b6-9b2e-a2f181509c36.png)

After:
![image](https://user-images.githubusercontent.com/26576876/237022633-680030f9-6616-4467-be0e-2551f9e9242a.png)
