### PR TITLE
add github action for docker image push to ghcr registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: Release Docker image
+
+on:
+  push:
+    tags:
+      - "*"
+    branches:
+      - "*"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Get Tag Version
+        id: version
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF}" == "refs/heads/master" ]]; then
+            echo "::set-output name=TAG_VERSION::latest"
+          else
+            echo "::set-output name=TAG_VERSION::${GITHUB_REF##*/}"
+          fi
+      - name: Extract branch name
+        id: extract_branch
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+      - name: Log in to the container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Build and push image using tag
+      #   uses: docker/build-push-action@v3
+      #   with:
+      #     context: .
+      #     push: true
+      #     tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.TAG_VERSION }}
+      - name: Build and push image using branch name
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.extract_branch.outputs.branch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release Docker image
+name: Release Docker Image
 
 on:
   push:
@@ -32,19 +32,13 @@ jobs:
         shell: bash
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
       - name: Log in to the container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      # - name: Build and push image using tag
-      #   uses: docker/build-push-action@v3
-      #   with:
-      #     context: .
-      #     push: true
-      #     tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.TAG_VERSION }}
       - name: Build and push image using branch name
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: .
           push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ COPY . .
 
 EXPOSE 8080
 
-ENTRYPOINT [ "/bin/sh", "-c", "cd /app && npm run build -- --catalogUrl=${CATALOG_URL} --publicPath=${ROOT_PATH} && serve -s dist -l 8080" ]
+ENTRYPOINT [ "/bin/sh", "-c", "cd /app && npm run build -- --catalogUrl=${CATALOG_URL} --pathPrefix=${ROOT_PATH} && serve -s dist -l 8080" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:lts-alpine
 
-ARG catalogURL
+ENV CATALOG_URL null
+ENV ROOT_PATH /
 
 RUN npm install -g serve
 
@@ -12,11 +13,6 @@ RUN npm install
 
 COPY . .
 
-# 2. si build time plus long
-RUN npm run build -- --catalogUrl=$catalogURL
-
 EXPOSE 8080
 
-# 1. Essayer build par entrypoint, ARG
-
-CMD [ "serve", "-s", "dist", "-l", "8080" ]
+ENTRYPOINT [ "/bin/sh", "-c", "cd /app && npm run build -- --catalogUrl=${CATALOG_URL} --publicPath=${ROOT_PATH} && serve -s dist -l 8080" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,11 @@ RUN npm install
 
 COPY . .
 
-RUN npm run build -- --catalogUrl=$catalogURL --publicPath=/stac-browser/
+# 2. si build time plus long
+RUN npm run build -- --catalogUrl=$catalogURL
 
 EXPOSE 8080
+
+# 1. Essayer build par entrypoint, ARG
 
 CMD [ "serve", "-s", "dist", "-l", "8080" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN npm install
 
 COPY . .
 
-RUN npm run build -- --catalogUrl=$catalogURL
+RUN npm run build -- --catalogUrl=$catalogURL --publicPath=/stac-browser/
 
 EXPOSE 8080
 


### PR DESCRIPTION
- Adds GitHub Action for Docker image push to ghcr registry.
- Move the npm build to an entrypoint in order to allow us to customize base path (see ROOT_PATH) and catalog URL (see CATALOG_URL), which are compiled for the frontend. Note that this change makes the startup time longer, since npm build needs to be executed on container boot.

Reopens https://github.com/radiantearth/stac-browser/pull/242