### PR TITLE
add babel/plugin-proposal-optional-chaining

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "license": "ISC",
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^10.1.0",
+    "@babel/plugin-proposal-optional-chaining": "^7.21.0",
     "@musement/iso-duration": "^1.0.0",
     "@radiantearth/stac-fields": "1.1.1",
     "@radiantearth/stac-migrate": "~1.2.0",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "yargs": "^17.0.1"
   },
   "devDependencies": {
+    "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/plugin-proposal-optional-chaining": "^7.21.0",
     "@vue/cli-plugin-babel": "^5.0.4",
     "@vue/cli-plugin-eslint": "^5.0.4",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   "license": "ISC",
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^10.1.0",
-    "@babel/plugin-proposal-optional-chaining": "^7.21.0",
     "@musement/iso-duration": "^1.0.0",
     "@radiantearth/stac-fields": "1.1.1",
     "@radiantearth/stac-migrate": "~1.2.0",
@@ -61,6 +60,7 @@
     "yargs": "^17.0.1"
   },
   "devDependencies": {
+    "@babel/plugin-proposal-optional-chaining": "^7.21.0",
     "@vue/cli-plugin-babel": "^5.0.4",
     "@vue/cli-plugin-eslint": "^5.0.4",
     "@vue/cli-plugin-router": "^5.0.4",


### PR DESCRIPTION
Running `docker build . -t stac-browser:latest` raises the below error.  Adding this to `package.json` fixes the error.

```
 => ERROR [7/8] RUN npm run build --                                                                                                                            0.9s
------
 > [7/8] RUN npm run build --:
#11 0.520 
#11 0.520 > @radiantearth/stac-browser@3.0.1 build
#11 0.520 > vue-cli-service build
#11 0.520 
#11 0.862  ERROR  Error: Cannot find module '@babel/plugin-proposal-optional-chaining'
#11 0.862         Require stack:
#11 0.862         - /app/node_modules/@babel/core/lib/config/files/plugins.js
#11 0.862         - /app/node_modules/@babel/core/lib/config/files/index.js
#11 0.862         - /app/node_modules/@babel/core/lib/index.js
#11 0.862         - /app/node_modules/@vue/cli-plugin-babel/index.js
#11 0.862         - /app/node_modules/@vue/cli-service/lib/Service.js
#11 0.862         - /app/node_modules/@vue/cli-service/bin/vue-cli-service.js
#11 0.863 Error: Cannot find module '@babel/plugin-proposal-optional-chaining'
#11 0.863 Require stack:
#11 0.863 - /app/node_modules/@babel/core/lib/config/files/plugins.js
#11 0.863 - /app/node_modules/@babel/core/lib/config/files/index.js
#11 0.863 - /app/node_modules/@babel/core/lib/index.js
#11 0.863 - /app/node_modules/@vue/cli-plugin-babel/index.js
#11 0.863 - /app/node_modules/@vue/cli-service/lib/Service.js
#11 0.863 - /app/node_modules/@vue/cli-service/bin/vue-cli-service.js
#11 0.863     at Module._resolveFilename (node:internal/modules/cjs/loader:1075:15)
#11 0.863     at resolve (node:internal/modules/cjs/helpers:116:19)
#11 0.863     at tryRequireResolve (/app/node_modules/@babel/core/lib/config/files/plugins.js:102:11)
#11 0.863     at resolveStandardizedNameForRequire (/app/node_modules/@babel/core/lib/config/files/plugins.js:136:19)
#11 0.863     at resolveStandardizedName (/app/node_modules/@babel/core/lib/config/files/plugins.js:151:12)
#11 0.863     at loadPlugin (/app/node_modules/@babel/core/lib/config/files/plugins.js:47:20)
#11 0.863     at loadPlugin.next (<anonymous>)
#11 0.863     at createDescriptor (/app/node_modules/@babel/core/lib/config/config-descriptors.js:139:16)
#11 0.863     at createDescriptor.next (<anonymous>)
#11 0.863     at evaluateSync (/app/node_modules/gensync/index.js:251:28)
------
executor failed running [/bin/sh -c npm run build --]: exit code: 1
```