### PR TITLE
Using nginx as base docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,21 @@
-FROM node:lts-alpine
+FROM node:lts-alpine AS build-step
 
 ARG catalogURL
 
-RUN npm install -g serve
-
 WORKDIR /app
-
 COPY package*.json ./
-
 RUN npm install
-
 COPY . .
-
 RUN npm run build -- --catalogUrl=$catalogURL
+
+FROM nginx:alpine-slim
+COPY --from=build-step /app/dist /usr/share/nginx/html
+
+# change default port to 8080
+RUN sed -i 's/\s*listen\s*80;/    listen 8080;/' /etc/nginx/conf.d/default.conf
 
 EXPOSE 8080
 
-CMD [ "serve", "-s", "dist", "-l", "8080" ]
+STOPSIGNAL SIGTERM
+
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
Using nginx:alpine-slim as docker base image and copy everything from the build-stage to the served directories.

Using port 8080 to stay backwards compatible.

Reduces image size from 750 MB to 25MB