### PR TITLE
Allow Collection Search result to be used in Item Search

### DIFF
--- a/src/components/Catalog.vue
+++ b/src/components/Catalog.vue
@@ -10,10 +10,10 @@
         <b-badge v-for="format in fileFormats" :key="format" variant="secondary" class="mr-1 mt-1 fileformat">{{ format | formatMediaType }}</b-badge>
         {{ data.description | summarize }}
       </b-card-text>
-      <b-card-text v-if="temporalExtent" class="datetime"><span v-html="temporalExtent" /></b-card-text>
+      <b-card-text v-if="temporalExtent" class="datetime"><small v-html="temporalExtent" /></b-card-text>
     </b-card-body>
     <b-card-footer>
-      <slot name="footer" v-bind:data="data"></slot>
+      <slot name="footer" :data="data" />
     </b-card-footer>
   </b-card>
 </template>
@@ -111,11 +111,12 @@ export default {
     .card-body, .card-footer {
       position: relative;
     }
-
     .card-footer:empty {
       display: none;
     }
-
+    .card-title {
+      margin-bottom: 0.5rem;
+    }
     .intro {
       display: -webkit-box;
       -webkit-line-clamp: 3;
@@ -124,30 +125,23 @@ export default {
       overflow-wrap: anywhere;
       text-align: left;
     }
-      
+    &.has-extent {
+      .intro {
+        margin-bottom: 0.5rem;
+      }
+    }
+    .datetime {
+      color: map-get($theme-colors, "secondary");
+    }
     .badge.deprecated {
       text-transform: uppercase;
     }
   }
   .card-list {
-    flex-direction: row;
-
     .catalog-card {
       box-sizing: border-box;
-      margin-top: 0.5em;
-      margin-bottom: 0.5em;
-
-      &.has-extent:not(.has-thumbnail) {
-        padding-top: 0.75em;
-      }
-      
-      @include media-breakpoint-down(lg) {
-        margin-bottom: 0.2em;
-        .card-title {
-          margin-top: 0.6em;
-        }
-      }
-        
+      margin: 0.5em 0;
+      display: flex;
 
       .card-img-right {
         min-height: 100px;
@@ -157,45 +151,25 @@ export default {
         object-fit: contain;
         object-position: right;
       }
-
-      .intro {
-        display: -webkit-box;
-        -webkit-line-clamp: 2;
-        -webkit-box-orient: vertical;
-        overflow: hidden;
-        overflow-wrap: anywhere;
-        text-align: left;
-        margin-bottom: 0;
+      .card-footer {
+        min-width: 175px;
+        max-width: 175px;
+        border-top: 0;
       }
-      .datetime {
-        display: inline-block;
-        padding: $border-radius;
-        border: 0;
-        background-color: rgba(0,0,0,0.6);
-        color: map-get($theme-colors, "light");
-        border-radius: 0 0 0 $border-radius;
-        position: absolute;
-        top: 0;
-        right: 0;
-        font-size: 80%;
-        white-space: nowrap;
-        max-width: 100%;
-        text-overflow: ellipsis;
-        overflow: hidden;
+      .intro {
+        -webkit-line-clamp: 2;
       }
     }
   }
   .card-columns {
     .catalog-card {
       box-sizing: border-box;
-      margin-top: 0.5em;
-      margin-bottom: 0.5em;
+      margin-top: 0.5em 0;
       text-align: center;
 
       &.queued {
         min-height: 10rem;
       }
-
       .card-img {
         width: auto;
         height: auto;
@@ -204,10 +178,6 @@ export default {
       }
       .card-title {
         text-align: center;
-      }
-      .datetime {
-        color: map-get($theme-colors, "secondary");
-        font-size: 85%;
       }
     }
   }

--- a/src/components/Catalog.vue
+++ b/src/components/Catalog.vue
@@ -12,6 +12,9 @@
       </b-card-text>
       <b-card-text v-if="temporalExtent" class="datetime"><span v-html="temporalExtent" /></b-card-text>
     </b-card-body>
+    <b-card-footer>
+      <slot name="footer" v-bind:data="data"></slot>
+    </b-card-footer>
   </b-card>
 </template>
 
@@ -97,13 +100,20 @@ export default {
 
 #stac-browser {
   .catalog-card {
-
     &.deprecated {
       opacity: 0.5;
 
       &:hover {
         opacity: 1;
       }
+    }
+
+    .card-body, .card-footer {
+      position: relative;
+    }
+
+    .card-footer:empty {
+      display: none;
     }
 
     .intro {

--- a/src/components/Catalogs.vue
+++ b/src/components/Catalogs.vue
@@ -16,8 +16,8 @@
       <Loading v-if="loading" fill top />
       <component :is="cardsComponent" v-bind="cardsComponentProps">
         <Catalog v-for="catalog in catalogView" :catalog="catalog" :key="catalog.href">
-          <template v-slot:footer="{data}">
-            <slot name="catalogFooter" v-bind:data="data"></slot>
+          <template #footer="{data}">
+            <slot name="catalogFooter" :data="data" />
           </template>
         </Catalog>
       </component>

--- a/src/components/Catalogs.vue
+++ b/src/components/Catalogs.vue
@@ -15,7 +15,11 @@
     <section class="list">
       <Loading v-if="loading" fill top />
       <component :is="cardsComponent" v-bind="cardsComponentProps">
-        <Catalog v-for="catalog in catalogView" :catalog="catalog" :key="catalog.href" />
+        <Catalog v-for="catalog in catalogView" :catalog="catalog" :key="catalog.href">
+          <template v-slot:footer="{data}">
+            <slot name="catalogFooter" v-bind:data="data"></slot>
+          </template>
+        </Catalog>
       </component>
     </section>
     <Pagination v-if="showPagination" :pagination="pagination" @paginate="paginate" />

--- a/src/components/Item.vue
+++ b/src/components/Item.vue
@@ -116,7 +116,7 @@ export default {
     &.description {
       .intro {
         text-align: left;
-        margin-bottom: 0.75rem;
+        margin-bottom: 0.5rem;
       }
     }
 

--- a/src/components/Item.vue
+++ b/src/components/Item.vue
@@ -130,8 +130,10 @@ export default {
       max-width: 100%;
       max-height: 200px;
     }
+
     .card-body {
       text-align: center;
+      position: relative;
     }
   }
 }

--- a/src/components/Items.vue
+++ b/src/components/Items.vue
@@ -77,6 +77,10 @@ export default {
       type: Boolean,
       default: true
     },
+    showFilters: {
+      type: Boolean,
+      default: false
+    },
     apiFilters: {
       type: Object,
       default: () => ({})
@@ -93,7 +97,7 @@ export default {
   data() {
     return {
       shownItems: this.chunkSize,
-      filtersOpen: false,
+      filtersOpen: this.showFilters,
       sort: 0
     };
   },
@@ -133,8 +137,21 @@ export default {
       return false;
     }
   },
+  watch: {
+    showFilters() {
+      this.filter = this.showFilters;
+    },
+    filtersOpen() {
+      this.$emit('filtersShown', this.filtersOpen);
+    }
+  },
   created() {
     this.sort = this.cardViewSort;
+  },
+  mounted() {
+    if (this.showFilters) {
+      setTimeout(() => Utils.scrollTo(this.$el), 250);
+    }
   },
   methods: {
     emitFilter(value, reset) {

--- a/src/components/SearchFilter.vue
+++ b/src/components/SearchFilter.vue
@@ -273,12 +273,22 @@ export default {
     },
     value: {
       immediate: true,
+      deep: true,
       handler(value) {
         let query = Object.assign(getQueryDefaults(), value);
         if (Array.isArray(query.datetime)) {
           query.datetime = query.datetime.map(Utils.dateFromUTC);
         }
         this.query = query;
+        if (Array.isArray(query.collections)) {
+          if (this.collections.length > 0) {
+            this.selectedCollections = this.collections
+              .filter(c => query.collections.includes(c.value));
+          }
+          else {
+            this.selectedCollections = query.collections.slice(0);
+          }
+        }
       }
     }
   },
@@ -345,17 +355,20 @@ export default {
       let apiCollections = this.parent.getChildren('collections');
       let nextCollectionsLink = this.parent._apiChildren.next;
       if (!Array.isArray(apiCollections) || nextCollectionsLink || !this.conformances.CollectionIdFilter) {
-          this.collections = [];
-          return;
-        }
-        this.collections = this.prepareCollections(apiCollections);
+        this.collections = [];
+        return;
+      }
+      this.collections = this.prepareCollections(apiCollections);
+    },
+    collectionToMultiSelect(c) {
+      return {
+        value: c.id,
+        text: c.title || c.id
+      };
     },
     prepareCollections(collections) {
       return collections
-        .map(c => ({
-          value: c.id,
-          text: c.title || c.id
-        }))
+        .map(this.collectionToMultiSelect)
         .sort((a,b) => a.text.localeCompare(b.text, this.uiLanguage));
     },
     findQueryableLink(links) {

--- a/src/locales/de/texts.json
+++ b/src/locales/de/texts.json
@@ -201,6 +201,7 @@
     "enterSearchTerms": "Gebe Suchbegriffe ein...",
     "equalTo": "entspricht genau",
     "filterBySpatialExtent": "Filtern nach räumlicher Ausdehnung",
+    "filterCollection": "Im Katalog filtern",
     "freeText": "Suchbegriffe",
     "freeTextDescription": "Suche nach mindestens einem der angegebene Begriffen in Feldern wie dem Titel und der Beschreibung.",
     "greaterThan": "größer als",
@@ -224,8 +225,8 @@
     "notFullySupported": "Eventuell werden nicht alle Optionen unterstützt.",
     "notSupported": "Suchen wird von dem Diensteanbieter nicht unterstützt.",
     "placeholder": "Suchen...",
-    "searchItemsForCollection": "Suche nach Elementen",
     "selectCollections": "Wähle Kataloge...",
+    "selectForItemSearch": "Markiere für Elementsuche",
     "sortOptions": {
       "datetime": "Datum und Zeit",
       "id": "Identifikationsnummer",
@@ -237,7 +238,8 @@
       "items": "Elemente durchsuchen"
     },
     "temporalExtent": "Zeitliche Ausdehnung",
-    "title": "Suche"
+    "title": "Suche",
+    "useInItemSearch": "Nutze Katalog in Elementsuche | Nutze {count} Kataloge in Elementsuche"
   },
   "showMore": "Zeige mehr...",
   "sidebar": {

--- a/src/locales/de/texts.json
+++ b/src/locales/de/texts.json
@@ -224,6 +224,7 @@
     "notFullySupported": "Eventuell werden nicht alle Optionen unterstützt.",
     "notSupported": "Suchen wird von dem Diensteanbieter nicht unterstützt.",
     "placeholder": "Suchen...",
+    "searchItemsForCollection": "Suche nach Elementen",
     "selectCollections": "Wähle Kataloge...",
     "sortOptions": {
       "datetime": "Datum und Zeit",

--- a/src/locales/en/texts.json
+++ b/src/locales/en/texts.json
@@ -224,6 +224,7 @@
     "notFullySupported": "Not all of the options may be supported.",
     "notSupported": "Item Search is not supported by the API.",
     "placeholder": "Search...",
+    "searchItemsForCollection": "Search for Items",
     "selectCollections": "Select one or multiple collections...",
     "sortOptions": {
       "datetime": "Date and Time",

--- a/src/locales/en/texts.json
+++ b/src/locales/en/texts.json
@@ -122,10 +122,10 @@
   },
   "items": {
     "filter": "Filters",
-    "showFilter": "Show Filters",
     "hideFilter": "Hide Filters",
     "noTime": "No time given",
-    "noneAvailableForCollection": "No items available for this collection."
+    "noneAvailableForCollection": "No items available for this collection.",
+    "showFilter": "Show Filters"
   },
   "leaflet": {
     "close": "Close",
@@ -201,6 +201,7 @@
     "enterSearchTerms": "Enter one or more search terms...",
     "equalTo": "equal to",
     "filterBySpatialExtent": "Filter by spatial extent",
+    "filterCollection": "Filter Collection",
     "freeText": "Search Terms",
     "freeTextDescription": "Search for at least one of the given terms in fields such as the title and the description.",
     "greaterThan": "greater than",
@@ -224,8 +225,8 @@
     "notFullySupported": "Not all of the options may be supported.",
     "notSupported": "Item Search is not supported by the API.",
     "placeholder": "Search...",
-    "searchItemsForCollection": "Search for Items",
     "selectCollections": "Select one or multiple collections...",
+    "selectForItemSearch": "Select for Item Search",
     "sortOptions": {
       "datetime": "Date and Time",
       "id": "ID",
@@ -237,7 +238,8 @@
       "items": "Search for Items"
     },
     "temporalExtent": "Temporal Extent",
-    "title": "Search"
+    "title": "Search",
+    "useInItemSearch": "Open Collection in Item Search | Open {count} Collections in Item Search"
   },
   "showMore": "Show more...",
   "sidebar": {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -445,15 +445,23 @@ function getStore(config, router) {
       setAuthData(state, value) {
         state.authData = value;
       },
+      state(state, newState) {
+        state.stateQueryParameters = newState;
+      },
+      updateState(state, {type, value}) {
+        if (value === null || typeof value === 'undefined') {
+          Vue.delete(state.stateQueryParameters, type);
+        }
+        else {
+          Vue.set(state.stateQueryParameters, type, value);
+        }
+      },
       openCollapsible(state, { type, uid }) {
         const idx = state.stateQueryParameters[type].indexOf(uid);
         // need to prevent duplicates because of the way the collapse v-model works
         if (idx === -1) {
           state.stateQueryParameters[type].push(uid);
         }
-      },
-      state(state, newState) {
-        state.stateQueryParameters = newState;
       },
       closeCollapsible(state, { type, uid }) {
         const idx = state.stateQueryParameters[type].indexOf(uid);

--- a/src/views/Catalog.vue
+++ b/src/views/Catalog.vue
@@ -46,9 +46,11 @@
       </b-col>
       <b-col class="items-container" v-if="hasItems">
         <Items
-          :stac="data" :items="items" :api="isApi" :apiFilters="filters"
+          :stac="data" :items="items" :api="isApi"
+          :showFilters="showFilters" :apiFilters="filters"
           :pagination="itemPages" :loading="apiItemsLoading"
           @paginate="paginateItems" @filterItems="filterItems"
+          @filtersShown="filtersShown"
         />
         <Assets v-if="hasItemAssets" :assets="data.item_assets" :definition="true" />
       </b-col>
@@ -131,8 +133,11 @@ export default {
     };
   },
   computed: {
-    ...mapState(['data', 'url', 'apiItems', 'apiItemsLink', 'apiItemsPagination', 'nextCollectionsLink']),
+    ...mapState(['data', 'url', 'apiItems', 'apiItemsLink', 'apiItemsPagination', 'nextCollectionsLink', 'stateQueryParameters']),
     ...mapGetters(['additionalLinks', 'catalogs', 'collectionLink', 'isCollection', 'items', 'getApiItemsLoading', 'parentLink', 'rootLink']),
+    showFilters() {
+      return Boolean(this.stateQueryParameters['itemFilterOpen']);
+    },
     hasThumbnails() {
       return this.thumbnails.length > 0;
     },
@@ -223,6 +228,9 @@ export default {
     }
   },
   methods: {
+    filtersShown(show) {
+        this.$store.commit('updateState', {type: 'itemFilterOpen', value: show ? 1 : null});
+    },
     loadMoreCollections() {
       this.$store.dispatch('loadNextApiCollections', {show: true});
     },

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -31,7 +31,11 @@
           <Catalogs
             v-if="isCollectionSearch" :catalogs="results" collectionsOnly
             :pagination="pagination" :loading="loading" @paginate="loadResults"
-          />
+          >
+            <template v-if="canSearchItems" #catalogFooter="{data}">
+              <a href="#" @click.prevent="openInItemSearch(data)" class="stretched-link">{{ $t('search.searchItemsForCollection') }}</a>
+            </template>
+          </Catalogs>
           <Items
             v-else
             :stac="stac" :items="results" :api="true" :allowFilter="false"
@@ -185,6 +189,12 @@ export default {
     }
   },
   methods: {
+    openInItemSearch(collection) {
+      if (Utils.isObject(collection) && collection.id) {
+        this.$set(this.itemFilters, 'collections', [collection.id]);
+      }
+      this.activeSearch = 1;
+    },
     async loadResults(link) {
       this.error = null;
       this.loading = true;

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -21,8 +21,8 @@
       </b-col>
       <b-col class="right">
         <b-alert v-if="error" variant="error" show>{{ error }}</b-alert>
-        <b-alert v-else-if="!data && !hasFilters" variant="info" show>{{ $t('search.modifyCriteria') }}</b-alert>
         <Loading v-else-if="!data && loading" fill top />
+        <b-alert v-else-if="data === null" variant="info" show>{{ $t('search.modifyCriteria') }}</b-alert>
         <b-alert v-else-if="results.length === 0" variant="warning" show>{{ $t('search.noItemsFound') }}</b-alert>
         <template v-else>
           <div id="search-map" v-if="itemCollection">
@@ -32,8 +32,15 @@
             v-if="isCollectionSearch" :catalogs="results" collectionsOnly
             :pagination="pagination" :loading="loading" @paginate="loadResults"
           >
-            <template v-if="canSearchItems" #catalogFooter="{data}">
-              <a href="#" @click.prevent="openInItemSearch(data)" class="stretched-link">{{ $t('search.searchItemsForCollection') }}</a>
+            <template #catalogFooter="slot">
+              <b-button-group v-if="canSearchItems || canFilterItems(slot.data)" vertical size="sm">
+                <b-button v-if="canSearchItems" variant="outline-primary" :pressed="selectedCollections[slot.data.id]" @click="selectForItemSearch(slot.data)">
+                  <b-icon-check-square v-if="selectedCollections[slot.data.id]" />
+                  <b-icon-square v-else />
+                  <span class="ml-2">{{ $t('search.selectForItemSearch') }}</span>
+                </b-button>
+                <StacLink :button="{variant: 'outline-primary', disabled: canFilterItems(slot.data)}" :data="slot.data" :title="$t('search.filterCollection')" :state="{itemFilterOpen: 1}" />
+              </b-button-group>
             </template>
           </Catalogs>
           <Items
@@ -44,6 +51,11 @@
         </template>
       </b-col>
     </b-row>
+    <b-alert v-if="selectedCollectionCount > 0" show variant="dark" class="selected-collections-action">
+      <b-button @click="openItemSearch" variant="primary" size="lg">
+        {{ $tc('search.useInItemSearch', selectedCollectionCount, {count: selectedCollectionCount}) }}
+      </b-button>
+    </b-alert>
   </main>
 </template>
 
@@ -53,19 +65,22 @@ import Utils from '../utils';
 import SearchFilter from '../components/SearchFilter.vue';
 import Loading from '../components/Loading.vue';
 import STAC from '../models/stac';
-import { BTabs, BTab } from 'bootstrap-vue';
-import { stacRequest } from '../store/utils';
+import { BIconCheckSquare, BIconSquare, BTabs, BTab } from 'bootstrap-vue';
+import { processSTAC, stacRequest } from '../store/utils';
 
 export default {
   name: "Search",
   components: {
+    BIconCheckSquare,
+    BIconSquare,
     BTab,
     BTabs,
     Catalogs: () => import('../components/Catalogs.vue'),
-    SearchFilter,
-    Items: () => import('../components/Items.vue'),
     Loading,
-    Map: () => import('../components/Map.vue')
+    Items: () => import('../components/Items.vue'),
+    Map: () => import('../components/Map.vue'),
+    SearchFilter,
+    StacLink: () => import('../components/StacLink.vue')
   },
   props: {
     loadParent: {
@@ -84,12 +99,16 @@ export default {
 
       itemFilters: {},
       collectionFilters: {},
-      activeSearch: 0
+      activeSearch: 0,
+      selectedCollections: {}
     };
   },
   computed: {
     ...mapState(['catalogUrl', 'catalogTitle', 'itemsPerPage']),
     ...mapGetters(['canSearch', 'canSearchItems', 'canSearchCollections', 'getStac', 'root', 'collectionLink', 'parentLink', 'fromBrowserPath', 'toBrowserPath']),
+    selectedCollectionCount() {
+      return Utils.size(this.selectedCollections);
+    },
     stac() {
       if (this.parent instanceof STAC) {
         return this.parent;
@@ -116,7 +135,7 @@ export default {
       };
     },
     results() {
-      if (!Utils.isObject(this.data)) {
+      if (Utils.size(this.data) === 0) {
         return [];
       }
       let list = this.isCollectionSearch ? this.data.collections : this.data.features;
@@ -135,7 +154,9 @@ export default {
             if (selfLink?.href) {
               url = Utils.toAbsolute(selfLink.href, this.link.href);
             }
-            return new STAC(obj, url, this.toBrowserPath(url));
+            let stac = new STAC(obj, url, this.toBrowserPath(url));
+            stac = processSTAC(this.$store.state, stac);
+            return stac;
           } catch (error) {
             console.error(error);
             return null;
@@ -145,9 +166,6 @@ export default {
     },
     pagination() {
       return Utils.getPaginationLinks(this.data);
-    },
-    hasFilters() {
-      return Utils.size(this.filters) > 0;
     },
     filters() {
       return this.isCollectionSearch ? this.collectionFilters : this.itemFilters;
@@ -161,6 +179,9 @@ export default {
     }
   },
   watch:{
+    activeSearch() {
+      this.data = null;
+    },
     searchLink: {
       immediate: true,
       handler() {
@@ -189,11 +210,24 @@ export default {
     }
   },
   methods: {
-    openInItemSearch(collection) {
-      if (Utils.isObject(collection) && collection.id) {
-        this.$set(this.itemFilters, 'collections', [collection.id]);
-      }
+    openItemSearch() {
+      this.$set(this.itemFilters, 'collections', Object.keys(this.selectedCollections));
       this.activeSearch = 1;
+      this.selectedCollections = {};
+    },
+    selectForItemSearch(collection) {
+      if (this.selectedCollections[collection.id]) {
+        this.$delete(this.selectedCollections, collection.id);
+      }
+      else {
+        this.$set(this.selectedCollections, collection.id, true);
+      }
+    },
+    canFilterItems(data) {
+      if (data instanceof STAC) {
+        return Boolean(data.getApiItemsLink());
+      }
+      return false;
     },
     async loadResults(link) {
       this.error = null;
@@ -207,14 +241,14 @@ export default {
           this.showPage(response.config.url);
         }
         if (!Utils.isObject(response.data) || !Array.isArray(response.data[key])) {
-          this.data = null;
+          this.data = {};
           this.error = this.$t(this.isCollectionSearch ? 'errors.invalidStacCollections' : 'errors.invalidStacItems');
         }
         else {
           this.data = response.data;
         }
       } catch (error) {
-        this.data = null;
+        this.data = {};
         this.error = error.message;
       } finally {
         this.loading = false;
@@ -246,6 +280,9 @@ export default {
 </script>
 
 <style lang="scss">
+@import '~bootstrap/scss/mixins';
+@import "../theme/variables.scss";
+
 #stac-browser {
   .search .left .tabs .tab-content .filter .card {
     border-top: 0;
@@ -253,12 +290,17 @@ export default {
     border-top-right-radius: 0;
   }
 }
-</style>
-<style lang="scss">
-@import '~bootstrap/scss/mixins';
-@import "../theme/variables.scss";
 
 #stac-browser .search {
+  .selected-collections-action {
+    position: fixed;
+    bottom: 0;
+    right: 0;
+    z-index: 5000;
+    margin: 1rem;
+    box-shadow: 2px 2px 4px 0px rgba(0, 0, 0, 0.25);
+  }
+
   .left {
     min-width: 350px;
     flex-basis: 40%;


### PR DESCRIPTION
Allows to:
- click a link to filter the collections (if available, otherwise disabled). It navigates to the collection, scrolls to the filter box and opens it.
- multi select for global Item Search. It actually works across multiple pages and seemed more versatile than just selecting one collection, which is already covered by the previous option.

![grafik](https://github.com/radiantearth/stac-browser/assets/8262166/530f3354-e423-49e5-beb7-57c0e9fdca31)

cc @ycespb