### PR TITLE
Make the default list of catalogs configurable

### DIFF
--- a/config.js
+++ b/config.js
@@ -39,5 +39,8 @@ module.exports = {
     requestHeaders: {},
     requestQueryParameters: {},
     preprocessSTAC: null,
-    authConfig: null
+    authConfig: null,
+    indexURL: "https://stacindex.org",
+    indexCatalogsURL: "https://stacindex.org/api/catalogs",
+    indexName: "STAC Index"
 };

--- a/config.schema.json
+++ b/config.schema.json
@@ -274,6 +274,26 @@
       },
       "noCLI": true,
       "noEnv": true
+    },
+    "indexURL": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "uri"
+    },
+    "indexCatalogsURL": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "uri"
+    },
+    "indexName": {
+      "type": [
+        "string",
+        "null"
+      ]
     }
   }
 }

--- a/docs/options.md
+++ b/docs/options.md
@@ -43,6 +43,9 @@ The following ways to set config options are possible:
 * [requestQueryParameters](#requestqueryparameters)
 * [authConfig](#authconfig)
 * [preprocessSTAC](#preprocessstac)
+* [indexURL](#indexurl)
+* [indexCatalogsURL](#indexcatalogsurl)
+* [indexName](#indexname)
 
 ## catalogUrl
 
@@ -52,7 +55,7 @@ The URL provided here **must** match exactly with the `href` that is provided as
 
 This is usually a URL provided as string, but in the config file you can also provide a function without parameters that returns the URL, e.g. `() => window.origin.toString().replace(/\/?$/, '/')`.
 
-If `catalogUrl` is empty or set to `null` STAC Browser switches to a mode where it defaults to a screen where you can either insert a catalog URL or select a catalog from [stacindex.org](https://stacindex.org).
+If `catalogUrl` is empty or set to `null` STAC Browser switches to a mode where it defaults to a screen where you can either insert a catalog URL or select a catalog from [indexUrl](#indexurl).
 
 ## catalogTitle
 
@@ -348,3 +351,35 @@ preprocessSTAC: (stac, state) => {
     return stac;
 }
 ```
+
+## indexURL
+
+The URL of a webpage that displays information about the STAC catalogs listed in [indexCatalogsURL](#indexcatalogsurl)
+on the default landing page when [catalogUrl](#catalogurl) is not set.
+
+If this is set to `null` or an empty string, no link will be displayed.
+
+Please note that this URL is used for informational purposes only and there is no validation that checks that the
+[indexURL](#indexurl) and the [indexCatalogsURL](#indexcatalogsurl) contain information about the same catalogs.
+
+The default value is: [https://stacindex.org](https://stacindex.org)
+
+## indexCatalogsURL
+
+A URL that returns a JSON array of STAC catalog objects to be displayed on the default landing page when 
+[catalogUrl](#catalogurl) is not set.
+
+If this is set to `null` or an empty string, no catalogs will be displayed and the user will only have the option to
+select a catalog by providing a URL themselves.
+
+Please note that there is no validation that checks that the [indexURL](#indexurl) and the 
+[indexCatalogsURL](#indexcatalogsurl) contain information about the same catalogs.
+
+The default value is: [https://stacindex.org/api/catalogs](https://stacindex.org/api/catalogs)
+
+## indexName
+
+The name of the page referred to by [indexURL](#indexurl). This name will be used as the text for a link on the default 
+landing page when [catalogUrl](#catalogurl) is not set.
+
+The default value is: `STAC Index`

--- a/src/views/SelectDataSource.vue
+++ b/src/views/SelectDataSource.vue
@@ -14,7 +14,8 @@
       <template #label>
         <i18n path="index.selectStacIndex">
           <template #stacIndex>
-            <a href="https://stacindex.org" target="_blank">STAC Index</a>
+            <a v-if="indexURL()" v-bind:href="indexURL()" target="_blank">{{ indexName() }}</a>
+            <span v-else>{{ indexName() }}</span>
           </template>
         </i18n>
       </template>
@@ -40,6 +41,7 @@ import { mapGetters } from "vuex";
 import Description from '../components/Description.vue';
 import Utils from '../utils';
 import axios from "axios";
+import {indexCatalogsURL, indexName, indexURL} from "../../config";
 
 export default {
   name: "SelectDataSource",
@@ -83,9 +85,12 @@ export default {
   async created() {
     // Reset loaded STAC catalog
     this.$store.commit('resetCatalog', true);
+    if (!indexCatalogsURL) {
+      return
+    }
     // Load entries from STAC Index
     try {
-      let response = await axios.get('https://stacindex.org/api/catalogs');
+      let response = await axios.get(indexCatalogsURL);
       if(Array.isArray(response.data)) {
         this.stacIndex = response.data;
       }
@@ -94,6 +99,12 @@ export default {
     }
   },
   methods: {
+    indexURL() {
+      return indexURL
+    },
+    indexName() {
+      return indexName || ""
+    },
     show(catalog) {
       if (catalog.access === 'private') {
         return false;


### PR DESCRIPTION
### Motivation

Allows setting a custom list of catalogs to be displayed to the user when `catalogUrl` is not set.

Currently: 

> If `catalogUrl` is empty or set to `null` STAC Browser switches to a mode where it defaults to a screen where you can either insert a catalog URL or select a catalog from [stacindex.org](https://stacindex.org).

This PR allows the user to choose a URL other than https://stacindex.org and https://stacindex.org/api/catalogs in order to display a different list of catalogs if `catalogUrl` is not set.

### Changes

Adds three new config variables: 

- `indexURL`: The URL of a webpage that displays information about the STAC catalogs
- `indexCatalogsURL`: A URL that returns a JSON array of STAC catalog objects
- `indexName`: The name of the page referred to by indexURL

The defaults for all these variables are the same as the current hard-coded values. This means that all changes are fully backwards compatible and users should see *no change* to their stac-browser instances if these variables are not changed in their configuration.

