### PR TITLE
Synchronize search input with query & add manual BBox entry

### DIFF
--- a/src/components/BBoxEntry.vue
+++ b/src/components/BBoxEntry.vue
@@ -1,0 +1,85 @@
+<template>
+  <b-form-group>
+    <b-form-row>
+      <b-col>
+        <b-form-group label="x_min" label-for="x_min">
+          <b-form-input
+            id="x_min"
+            @input="updateBBoxArray($event, 0)" 
+            :value="bbox[0]"
+            type="number"
+            no-wheel
+            step="any"
+            min="-180"
+            max="180"
+          />
+        </b-form-group>
+      </b-col>
+      <b-col>
+        <b-form-group label="y_min" label-for="y_min">
+          <b-form-input
+            id="y_min"
+            @input="updateBBoxArray($event, 1)" 
+            :value="bbox[1]"
+            type="number"
+            no-wheel
+            step="any"
+            min="-90"
+            max="90"
+          />
+        </b-form-group>
+      </b-col>
+      <b-col>
+        <b-form-group label="x_max" label-for="x_max">  
+          <b-form-input
+            id="x_max"
+            @input="updateBBoxArray($event, 2)" 
+            :value="bbox[2]"
+            type="number"
+            no-wheel
+            step="any"
+            min="-180"
+            max="180"
+          />
+        </b-form-group>
+      </b-col>
+      <b-col>
+        <b-form-group label="y_max" label-for="y_max">
+          <b-form-input
+            id="y_max"
+            @input="updateBBoxArray($event, 3)"
+            :value="bbox[3]"
+            type="number"
+            no-wheel
+            step="any"
+            min="-90"
+            max="90"
+          />
+        </b-form-group>
+      </b-col>
+    </b-form-row>
+  </b-form-group>
+</template>
+
+<script>
+import { BFormInput, BFormGroup} from 'bootstrap-vue';
+
+export default {
+  name: 'BBoxEntry',
+components: {
+    BFormGroup,
+    BFormInput,
+  },
+props: {
+    bbox: {
+      type: Array,
+      required: true
+    }
+  },
+  methods: {
+    updateBBoxArray($event, position) {
+     this.$emit('updateBBoxArray', $event, position);
+   }
+ }
+};
+</script>

--- a/src/components/SearchFilter.vue
+++ b/src/components/SearchFilter.vue
@@ -266,7 +266,7 @@ function updateUrlParamString(key, value) {
   if(key === 'sortTerm') {
     searchURL.searchParams.set(key, JSON.stringify(value));
   } else if(key ==='datetime') {
-    const dateFormattedForPicker = `${JSON.stringify(value['0'])}/${JSON.stringify(value['1'])}`
+    const dateFormattedForPicker = `${JSON.stringify(value['0'])}/${JSON.stringify(value['1'])}`;
     searchURL.searchParams.set(key, dateFormattedForPicker.replaceAll('"',''));
   } else {
     searchURL.searchParams.set(key, value);

--- a/src/components/SearchFilter.vue
+++ b/src/components/SearchFilter.vue
@@ -40,66 +40,7 @@
                 <b-form-radio value="text">{{ $t('search.defineBbox.text') }}</b-form-radio>
               </b-form-radio-group>
             </b-form-group>
-            <b-form-group v-if="provideBBox && bboxSelectionStyle === 'text'">
-              <b-form-row>
-                <b-col>
-                  <b-form-group label="x_min" label-for="x_min">
-                    <b-form-input
-                      id="x_min"
-                      @input="updateBBoxArray($event, 0)" 
-                      :value="query.bbox ? query.bbox[0] : -180"
-                      type="number"
-                      no-wheel
-                      step="any"
-                      min="-180"
-                      max="180"
-                    />
-                  </b-form-group>
-                </b-col>
-                <b-col>
-                  <b-form-group label="y_min" label-for="y_min">
-                    <b-form-input
-                      id="y_min"
-                      @input="updateBBoxArray($event, 1)" 
-                      :value="query.bbox ? query.bbox[1] : -80"
-                      type="number"
-                      no-wheel
-                      step="any"
-                      min="-90"
-                      max="90"
-                    />
-                  </b-form-group>
-                </b-col>
-                <b-col>
-                  <b-form-group label="x_max" label-for="x_max">  
-                    <b-form-input
-                      id="x_max"
-                      @input="updateBBoxArray($event, 2)" 
-                      :value="query.bbox ? query.bbox[2] : 180"
-                      type="number"
-                      no-wheel
-                      step="any"
-                      min="-180"
-                      max="180"
-                    />
-                  </b-form-group>
-                </b-col>
-                <b-col>
-                  <b-form-group label="y_max" label-for="y_max">
-                    <b-form-input
-                      id="y_max"
-                      @input="updateBBoxArray($event, 3)"
-                      :value="query?.bbox ? query.bbox[3] : 80"
-                      type="number"
-                      no-wheel
-                      step="any"
-                      min="-90"
-                      max="90"
-                    />
-                  </b-form-group>
-                </b-col>
-              </b-form-row>
-            </b-form-group>
+            <BBoxEntry v-if="provideBBox && bboxSelectionStyle === 'text'" :bbox="query.bbox || [180, 80, 180, 80]" @updateBBoxArray="updateBBoxArray" />
             <Map class="mb-4" v-if="provideBBox && bboxSelectionStyle === 'map'" :stac="stac" selectBounds @bounds="setBBox" scrollWheelZoom />
           </template>
         </b-form-group>
@@ -196,6 +137,7 @@ import Multiselect from 'vue-multiselect';
 import { mapGetters, mapState } from "vuex";
 import refParser from '@apidevtools/json-schema-ref-parser';
 
+import BBoxEntry from './BBoxEntry.vue';
 import Utils, { schemaMediaType } from '../utils';
 import { ogcQueryables } from "../rels";
 
@@ -339,6 +281,7 @@ export default {
   name: 'SearchFilter',
   components: {
     BBadge,
+    BBoxEntry,
     BDropdown,
     BDropdownItem,
     BForm,

--- a/src/components/SearchFilter.vue
+++ b/src/components/SearchFilter.vue
@@ -27,7 +27,7 @@
         </b-form-group>
 
         <b-form-group v-if="canFilterExtents" :label="$t('search.spatialExtent')" :label-for="ids.bbox">
-          <b-form-checkbox :id="ids.bbox" v-model="provideBBox" value="1" @change="setBBox()">{{ $t('search.filterBySpatialExtent') }}</b-form-checkbox>
+          <b-form-checkbox :id="ids.bbox" v-model="provideBBox" @change="setBBox()">{{ $t('search.filterBySpatialExtent') }}</b-form-checkbox>
           <Map class="mb-4" v-if="provideBBox" :stac="stac" selectBounds @bounds="setBBox" scrollWheelZoom />
         </b-form-group>
 
@@ -181,11 +181,17 @@ function getQueryValues() {
   return combinedQuery;
 }
 
+function bboxProvided() {
+      const searchURL = new URL(window.location);
+      const hasBbox = searchURL.searchParams.has('bbox');
+      return hasBbox;
+    }
+
 function getDefaults() {
   return {
     sortOrder: 1,
     sortTerm: null,
-    provideBBox: true,
+    provideBBox: bboxProvided(),
     query: getQueryDefaults(),
     filtersAndOr: 'and',
     filters: [],

--- a/src/components/SearchFilter.vue
+++ b/src/components/SearchFilter.vue
@@ -110,7 +110,7 @@
         </b-form-group>
       </b-card-body>
       <b-card-footer>
-        <b-button type="submit" variant="primary">{{ $t('submit') }}</b-button>
+        <b-button id="submitBtn" type="submit" variant="primary">{{ $t('submit') }}</b-button>
         <b-button type="reset" variant="danger" class="ml-3">{{ $t('reset') }}</b-button>
       </b-card-footer>
     </b-card>
@@ -138,17 +138,6 @@ import CqlLogicalOperator from '../models/cql2/operators/logical';
 import { CqlEqual } from '../models/cql2/operators/comparison';
 import { stacRequest } from '../store/utils';
 
-const allowedQueryParams = [
-  'q',
-  'datetime',
-  'bbox',
-  'limit',
-  'ids',
-  'collections',
-  'sortby',
-  'filters',
-  'itemsPerPage'];
-
 function getQueryDefaults() {
   return {
     q: [],
@@ -167,10 +156,25 @@ function getQueryValues() {
   const params = searchURL.searchParams;
   const urlParams = {};
   const arrayParams = ['bbox', 'collections', 'ids'];
+  const allowedQueryParams = [
+  'q',
+  'datetime',
+  'bbox',
+  'limit',
+  'ids',
+  'collections',
+  'sortby',
+  'filters',
+  'itemsPerPage'];
+  
   allowedQueryParams.forEach((allowedParam) => {
     if (params.has(allowedParam)) {
       if( arrayParams.includes(allowedParam)) {
         urlParams[allowedParam] = params.get(allowedParam).split(',');
+        // bbox bust be array of numbers
+        if(allowedParam === 'bbox') {
+          urlParams[allowedParam] = urlParams[allowedParam].map(Number);
+        }
       } else {
         urlParams[allowedParam] = params.get(allowedParam);
       }
@@ -427,6 +431,14 @@ export default {
       );
     }
     Promise.all(promises).finally(() => this.loaded = true);
+  },
+  mounted() {
+    // submit form if loaded with url params
+  const searchURL = new URL(window.location);
+  const params = searchURL.searchParams;
+    if(params.size > 1) {
+      document.getElementById("submitBtn").click();
+    }
   },
   methods: {
     resetSearchCollection() {

--- a/src/locales/en/texts.json
+++ b/src/locales/en/texts.json
@@ -196,6 +196,10 @@
     "addSearchTerm": "Press enter to add a search term",
     "additionalFilters": "Additional filters",
     "dateDescription": "All times in Coordinated Universal Time (UTC).",
+    "defineBbox": {
+      "map": "Draw bounding box on map",
+      "text": "Enter coordinates"
+    },
     "enterCollections": "Enter one or more Collection IDs...",
     "enterItemIds": "Enter one or more Item IDs...",
     "enterSearchTerms": "Enter one or more search terms...",


### PR DESCRIPTION
Fixes #302 

This PR is intended to synchronize the filter options on the `/search` route with url parameters. 

![searchWithParams](https://github.com/radiantearth/stac-browser/assets/7388976/f18dee8f-5dcb-4388-92cc-42f6de832fd2)


1) parameters in the URL are saved as a user makes changes
2) loading the `/search` route with URL parameters submits the form
3) Because changing the form does update the URL parameters, hitting reload would actually submit the form, as well.
4) Clicking reset sets the form back to the default state and clears the url params. It is not returning to the state first navigated to by a user.
5) The areaselect component doesn't handle passing in a pre-selected area. Without that, it was hard for a user to determine what the spatial extent in the search was. My route to solve this was to add a new BBEntry component that allows the entry of `[x_min, y_min, x_max, y_max]`.  If a shared url has spatial extent defined, then the bounding box selection will be here. The default behavior remains using the bounding box.  This new component should also help accessibility, but a follow up task to update the areaSelect to accept an entry might be nice.



