### PR TITLE
Add Manual bbox entry option to search page

### DIFF
--- a/src/components/BBoxEntry.vue
+++ b/src/components/BBoxEntry.vue
@@ -1,0 +1,85 @@
+<template>
+  <b-form-group>
+    <b-form-row>
+      <b-col>
+        <b-form-group label="x_min" label-for="x_min">
+          <b-form-input
+            id="x_min"
+            @input="updateBBoxArray($event, 0)" 
+            :value="bbox[0]"
+            type="number"
+            no-wheel
+            step="any"
+            min="-180"
+            max="180"
+          />
+        </b-form-group>
+      </b-col>
+      <b-col>
+        <b-form-group label="y_min" label-for="y_min">
+          <b-form-input
+            id="y_min"
+            @input="updateBBoxArray($event, 1)" 
+            :value="bbox[1]"
+            type="number"
+            no-wheel
+            step="any"
+            min="-90"
+            max="90"
+          />
+        </b-form-group>
+      </b-col>
+      <b-col>
+        <b-form-group label="x_max" label-for="x_max">  
+          <b-form-input
+            id="x_max"
+            @input="updateBBoxArray($event, 2)" 
+            :value="bbox[2]"
+            type="number"
+            no-wheel
+            step="any"
+            min="-180"
+            max="180"
+          />
+        </b-form-group>
+      </b-col>
+      <b-col>
+        <b-form-group label="y_max" label-for="y_max">
+          <b-form-input
+            id="y_max"
+            @input="updateBBoxArray($event, 3)"
+            :value="bbox[3]"
+            type="number"
+            no-wheel
+            step="any"
+            min="-90"
+            max="90"
+          />
+        </b-form-group>
+      </b-col>
+    </b-form-row>
+  </b-form-group>
+</template>
+
+<script>
+import { BFormInput, BFormGroup} from 'bootstrap-vue';
+
+export default {
+  name: 'BBoxEntry',
+components: {
+    BFormGroup,
+    BFormInput,
+  },
+props: {
+    bbox: {
+      type: Array,
+      required: true
+    }
+  },
+  methods: {
+    updateBBoxArray($event, position) {
+     this.$emit('updateBBoxArray', $event, position);
+   }
+ }
+};
+</script>

--- a/src/components/SearchFilter.vue
+++ b/src/components/SearchFilter.vue
@@ -266,7 +266,7 @@ function updateUrlParamString(key, value) {
   if(key === 'sortTerm') {
     searchURL.searchParams.set(key, JSON.stringify(value));
   } else if(key ==='datetime') {
-    const dateFormattedForPicker = `${JSON.stringify(value['0'])}/${JSON.stringify(value['1'])}`
+    const dateFormattedForPicker = `${JSON.stringify(value['0'])}/${JSON.stringify(value['1'])}`;
     searchURL.searchParams.set(key, dateFormattedForPicker.replaceAll('"',''));
   } else {
     searchURL.searchParams.set(key, value);

--- a/src/components/SearchFilter.vue
+++ b/src/components/SearchFilter.vue
@@ -40,66 +40,7 @@
                 <b-form-radio value="text">{{ $t('search.defineBbox.text') }}</b-form-radio>
               </b-form-radio-group>
             </b-form-group>
-            <b-form-group v-if="provideBBox && bboxSelectionStyle === 'text'">
-              <b-form-row>
-                <b-col>
-                  <b-form-group label="x_min" label-for="x_min">
-                    <b-form-input
-                      id="x_min"
-                      @input="updateBBoxArray($event, 0)" 
-                      :value="query.bbox ? query.bbox[0] : -180"
-                      type="number"
-                      no-wheel
-                      step="any"
-                      min="-180"
-                      max="180"
-                    />
-                  </b-form-group>
-                </b-col>
-                <b-col>
-                  <b-form-group label="y_min" label-for="y_min">
-                    <b-form-input
-                      id="y_min"
-                      @input="updateBBoxArray($event, 1)" 
-                      :value="query.bbox ? query.bbox[1] : -80"
-                      type="number"
-                      no-wheel
-                      step="any"
-                      min="-90"
-                      max="90"
-                    />
-                  </b-form-group>
-                </b-col>
-                <b-col>
-                  <b-form-group label="x_max" label-for="x_max">  
-                    <b-form-input
-                      id="x_max"
-                      @input="updateBBoxArray($event, 2)" 
-                      :value="query.bbox ? query.bbox[2] : 180"
-                      type="number"
-                      no-wheel
-                      step="any"
-                      min="-180"
-                      max="180"
-                    />
-                  </b-form-group>
-                </b-col>
-                <b-col>
-                  <b-form-group label="y_max" label-for="y_max">
-                    <b-form-input
-                      id="y_max"
-                      @input="updateBBoxArray($event, 3)"
-                      :value="query?.bbox ? query.bbox[3] : 80"
-                      type="number"
-                      no-wheel
-                      step="any"
-                      min="-90"
-                      max="90"
-                    />
-                  </b-form-group>
-                </b-col>
-              </b-form-row>
-            </b-form-group>
+            <BBoxEntry v-if="provideBBox && bboxSelectionStyle === 'text'" :bbox="query.bbox || [180, 80, 180, 80]" @updateBBoxArray="updateBBoxArray" />
             <Map class="mb-4" v-if="provideBBox && bboxSelectionStyle === 'map'" :stac="stac" selectBounds @bounds="setBBox" scrollWheelZoom />
           </template>
         </b-form-group>
@@ -196,6 +137,7 @@ import Multiselect from 'vue-multiselect';
 import { mapGetters, mapState } from "vuex";
 import refParser from '@apidevtools/json-schema-ref-parser';
 
+import BBoxEntry from './BBoxEntry.vue';
 import Utils, { schemaMediaType } from '../utils';
 import { ogcQueryables } from "../rels";
 
@@ -339,6 +281,7 @@ export default {
   name: 'SearchFilter',
   components: {
     BBadge,
+    BBoxEntry,
     BDropdown,
     BDropdownItem,
     BForm,

--- a/src/components/SearchFilter.vue
+++ b/src/components/SearchFilter.vue
@@ -27,7 +27,7 @@
         </b-form-group>
 
         <b-form-group v-if="canFilterExtents" :label="$t('search.spatialExtent')" :label-for="ids.bbox">
-          <b-form-checkbox :id="ids.bbox" v-model="provideBBox" value="1" @change="setBBox()">{{ $t('search.filterBySpatialExtent') }}</b-form-checkbox>
+          <b-form-checkbox :id="ids.bbox" v-model="provideBBox" @change="setBBox()">{{ $t('search.filterBySpatialExtent') }}</b-form-checkbox>
           <Map class="mb-4" v-if="provideBBox" :stac="stac" selectBounds @bounds="setBBox" scrollWheelZoom />
         </b-form-group>
 
@@ -181,11 +181,17 @@ function getQueryValues() {
   return combinedQuery;
 }
 
+function bboxProvided() {
+      const searchURL = new URL(window.location);
+      const hasBbox = searchURL.searchParams.has('bbox');
+      return hasBbox;
+    }
+
 function getDefaults() {
   return {
     sortOrder: 1,
     sortTerm: null,
-    provideBBox: true,
+    provideBBox: bboxProvided(),
     query: getQueryDefaults(),
     filtersAndOr: 'and',
     filters: [],

--- a/src/components/SearchFilter.vue
+++ b/src/components/SearchFilter.vue
@@ -110,7 +110,7 @@
         </b-form-group>
       </b-card-body>
       <b-card-footer>
-        <b-button type="submit" variant="primary">{{ $t('submit') }}</b-button>
+        <b-button id="submitBtn" type="submit" variant="primary">{{ $t('submit') }}</b-button>
         <b-button type="reset" variant="danger" class="ml-3">{{ $t('reset') }}</b-button>
       </b-card-footer>
     </b-card>
@@ -138,17 +138,6 @@ import CqlLogicalOperator from '../models/cql2/operators/logical';
 import { CqlEqual } from '../models/cql2/operators/comparison';
 import { stacRequest } from '../store/utils';
 
-const allowedQueryParams = [
-  'q',
-  'datetime',
-  'bbox',
-  'limit',
-  'ids',
-  'collections',
-  'sortby',
-  'filters',
-  'itemsPerPage'];
-
 function getQueryDefaults() {
   return {
     q: [],
@@ -167,10 +156,25 @@ function getQueryValues() {
   const params = searchURL.searchParams;
   const urlParams = {};
   const arrayParams = ['bbox', 'collections', 'ids'];
+  const allowedQueryParams = [
+  'q',
+  'datetime',
+  'bbox',
+  'limit',
+  'ids',
+  'collections',
+  'sortby',
+  'filters',
+  'itemsPerPage'];
+  
   allowedQueryParams.forEach((allowedParam) => {
     if (params.has(allowedParam)) {
       if( arrayParams.includes(allowedParam)) {
         urlParams[allowedParam] = params.get(allowedParam).split(',');
+        // bbox bust be array of numbers
+        if(allowedParam === 'bbox') {
+          urlParams[allowedParam] = urlParams[allowedParam].map(Number);
+        }
       } else {
         urlParams[allowedParam] = params.get(allowedParam);
       }
@@ -427,6 +431,14 @@ export default {
       );
     }
     Promise.all(promises).finally(() => this.loaded = true);
+  },
+  mounted() {
+    // submit form if loaded with url params
+  const searchURL = new URL(window.location);
+  const params = searchURL.searchParams;
+    if(params.size > 1) {
+      document.getElementById("submitBtn").click();
+    }
   },
   methods: {
     resetSearchCollection() {

--- a/src/components/SearchFilter.vue
+++ b/src/components/SearchFilter.vue
@@ -124,7 +124,7 @@
         </b-form-group>
       </b-card-body>
       <b-card-footer>
-        <b-button id="submitBtn" type="submit" variant="primary">{{ $t('submit') }}</b-button>
+        <b-button type="submit" variant="primary">{{ $t('submit') }}</b-button>
         <b-button type="reset" variant="danger" class="ml-3">{{ $t('reset') }}</b-button>
       </b-card-footer>
     </b-card>
@@ -166,52 +166,6 @@ function getQueryDefaults() {
   };
 }
 
-function getUrlParamValues() {
-  const searchURL = new URL(window.location);
-  const params = searchURL.searchParams;
-  const urlParams = {};
-  const arrayParams = ['bbox', 'collections', 'ids'];
-  const allowedQueryParams = [
-  'q',
-  'datetime',
-  'bbox',
-  'limit',
-  'ids',
-  'collections',
-  'sortby',
-  'filters',
-  'itemsPerPage'];
-  
-  allowedQueryParams.forEach((allowedParam) => {
-    if (params.has(allowedParam)) {
-      if( arrayParams.includes(allowedParam)) {
-        urlParams[allowedParam] = params.get(allowedParam).split(',');
-        // bbox bust be array of numbers
-        if(allowedParam === 'bbox') {
-          urlParams[allowedParam] = urlParams[allowedParam].map(Number);
-        }
-      } else if(allowedParam === 'datetime') {
-        // datetime must be array of date objects
-          urlParams[allowedParam] = params.get(allowedParam);
-          const dateArray= urlParams['datetime'].split('/').map( day => new Date(day));
-          urlParams[allowedParam] = dateArray;
-        } else {
-        // all others are strings
-        urlParams[allowedParam] = params.get(allowedParam);
-      }
-    }
-  });
-
-  const combinedQuery = { ...getQueryDefaults(), ...urlParams};
-  return combinedQuery;
-}
-
-function bboxProvided() {
-      const searchURL = new URL(window.location);
-      const hasBbox = searchURL.searchParams.has('bbox');
-      return hasBbox;
-    }
-
 function getDefaults() {
   return {
     sortOrder: 1,
@@ -223,56 +177,6 @@ function getDefaults() {
     selectedCollections: [],
     bboxSelectionStyle: 'map'
   };
-}
-
-function overwriteDefaults() {
-  const searchURL = new URL(window.location);
-  const params = searchURL.searchParams;
-  const permittedOverwrites = ['sortOrder', 'sortTerm', 'provideBBox'];
-  const numericParams=['sortOrder', 'limit'];
-  const defaultOverwrites = {
-    provideBBox: bboxProvided(),
-    bboxSelectionStyle: bboxProvided() ? 'text' : 'map',
-  };
-
-
-  permittedOverwrites.forEach((allowedValue) => {
-    if(params.has(allowedValue)) {
-      // sortTerm is a json object, not a string
-      if (allowedValue === 'sortTerm') {
-        defaultOverwrites[allowedValue] = JSON.parse(params.get(allowedValue));
-      }
-      else if(numericParams.includes(allowedValue)) {
-        defaultOverwrites[allowedValue] = parseInt(params.get(allowedValue));
-      } else {
-        defaultOverwrites[allowedValue] = params.get(allowedValue);
-      }
-    }
-  });
-
-  return {...getDefaults(), ...defaultOverwrites};
-
-}
-
-function updateUrlParamString(key, value) {
-  // remove parameters if new value is null
-  const searchURL = new URL(window.location);
-  if (value === null || value.length === 0 || value.value === null) {
-    searchURL.searchParams.delete(key);
-    window.history.pushState({}, '', searchURL);
-    return;
-  }
-  // sortTerm is an object
-  if(key === 'sortTerm') {
-    searchURL.searchParams.set(key, JSON.stringify(value));
-  } else if(key ==='datetime') {
-    const dateFormattedForPicker = `${JSON.stringify(value['0'])}/${JSON.stringify(value['1'])}`;
-    searchURL.searchParams.set(key, dateFormattedForPicker.replaceAll('"',''));
-  } else {
-    searchURL.searchParams.set(key, value);
-  }
-
-  window.history.pushState({}, '', searchURL);
 }
 
 let formId = 0;
@@ -288,8 +192,8 @@ export default {
     BFormGroup,
     BFormInput,
     BFormCheckbox,
-    BFormRadio,
     BFormRadioGroup,
+    BFormRadio,
     QueryableInput: () => import('./QueryableInput.vue'),
     Loading,
     Map: () => import('./Map.vue'),
@@ -316,10 +220,6 @@ export default {
     value: {
       type: Object,
       default: () => ({})
-    },
-    searchLink: {
-      type: Object,
-      default: () => ({})
     }
   },
   data() {
@@ -332,7 +232,7 @@ export default {
       collections: [],
       collectionsLoadingTimer: null,
       additionalCollectionCount: 0
-    }, overwriteDefaults());
+    }, getDefaults());
   },
   computed: {
     ...mapState(['itemsPerPage', 'uiLanguage']),
@@ -415,7 +315,7 @@ export default {
       immediate: true,
       deep: true,
       handler(value) {
-        let query = Object.assign(getUrlParamValues(), value);
+        let query = Object.assign(getQueryDefaults(), value);
         if (Array.isArray(query.datetime)) {
           query.datetime = query.datetime.map(Utils.dateFromUTC);
         }
@@ -430,8 +330,7 @@ export default {
           });
         }
       }
-    },
-    $route() {},
+    }
   },
   beforeCreate() {
     formId++;
@@ -459,14 +358,6 @@ export default {
       );
     }
     Promise.all(promises).finally(() => this.loaded = true);
-  },
-  mounted() {
-    // submit form if loaded with url params
-  const searchURL = new URL(window.location);
-  const params = searchURL.searchParams;
-    if(params.size > 1) {
-      document.getElementById("submitBtn").click();
-    }
   },
   methods: {
     resetSearchCollection() {
@@ -592,11 +483,9 @@ export default {
     },
     sortFieldSet(value) {
       this.sortTerm = value;
-      updateUrlParamString('sortTerm', value);
     },
     sortDirectionSet(value) {
       this.sortOrder = value;
-      updateUrlParamString('sortOrder', value);
     },
     buildFilter() {
       if (this.filters.length === 0) {
@@ -627,7 +516,6 @@ export default {
     async onReset() {
       Object.assign(this, getDefaults());
       this.$emit('input', {}, true);
-      this.removeQueryParams();
     },
     setLimit(limit) {
       limit = Number.parseInt(limit, 10);
@@ -638,24 +526,20 @@ export default {
         limit = null;
       }
       this.$set(this.query, 'limit', limit);
-      updateUrlParamString('limit', limit);
     },
     addSearchTerm(term) {
       if (!Utils.hasText(term)) {
         return;
       }
       this.query.q.push(term);
-      updateUrlParamString('q', term);
     },
     setSearchTerms(terms) {
       this.$set(this.query, 'q', terms);
-      updateUrlParamString('q', terms);
     },
     updateBBoxArray(entry, position) {
       const bbox = this.query.bbox;
       bbox[position] = Number(entry);
       this.$set(this.query, 'bbox', bbox);
-      updateUrlParamString('bbox', bbox);
     },
     setBBox(bounds) {
       let bbox = null;
@@ -676,7 +560,6 @@ export default {
         }
       }
       this.$set(this.query, 'bbox', bbox);
-      updateUrlParamString('bbox', bbox);
     },
     setDateTime(datetime) {
       if (datetime.find(dt => dt instanceof Date)) {
@@ -686,7 +569,6 @@ export default {
         datetime = null;
       }
       this.$set(this.query, 'datetime', datetime);
-      updateUrlParamString('datetime', datetime);
     },
     addCollection(collection) {
       if (!this.collectionSelectOptions.taggable) {
@@ -697,20 +579,16 @@ export default {
       this.selectedCollections.push(opt);
       this.collections.push(opt);
       this.query.collections.push(collection);
-      updateUrlParamString('collections', collection);
     },
     setCollections(collections) {
       this.selectedCollections = collections;
       this.$set(this.query, 'collections', collections.map(c => c.value));
-      updateUrlParamString('collections', collections.map(c => c.value));
     },
     addId(id) {
       this.query.ids.push(id);
-      updateUrlParamString('ids', id);
     },
     setIds(ids) {
       this.$set(this.query, 'ids', ids);
-      updateUrlParamString('ids', ids);
     },
     formatSort() {
       if (this.sortTerm && this.sortTerm.value && this.sortOrder) {
@@ -720,11 +598,8 @@ export default {
       else {
         return null;
       }
-    },
-    removeQueryParams() {
-      this.$router.replace({name: "search"});
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/src/locales/en/texts.json
+++ b/src/locales/en/texts.json
@@ -196,6 +196,10 @@
     "addSearchTerm": "Press enter to add a search term",
     "additionalFilters": "Additional filters",
     "dateDescription": "All times in Coordinated Universal Time (UTC).",
+    "defineBbox": {
+      "map": "Draw bounding box on map",
+      "text": "Enter coordinates"
+    },
     "enterCollections": "Enter one or more Collection IDs...",
     "enterItemIds": "Enter one or more Item IDs...",
     "enterSearchTerms": "Enter one or more search terms...",


### PR DESCRIPTION
As requested in PR #302 , This is breaking out a new feature into its own PR.  

AreaSelect            |  BBoxEntry
:-------------------------:|:-------------------------:
<img width="684" alt="defaultAreaSelect" src="https://github.com/radiantearth/stac-browser/assets/7388976/87edaf01-3a22-465a-9ce1-5ca156bd0bfd">|<img width="705" alt="newBBoxEntry" src="https://github.com/radiantearth/stac-browser/assets/7388976/bf2482a5-4ead-4213-a88b-b60535fdc4a1">

This PR is intended to add a new BBEntry component that allows the entry of [`x_min, y_min, x_max, y_max]` instead of using a bounding box selection on the map. This new component should help accessibility and help make it clear the coordinates being searched by a user.

The default behavior on the search page is still to show the areaSelect Component if a user checks the `Filter by spatial extent` option.  However, now there is a radio button option to toggle to "Enter coordinates". This option hides the area select and allows a user to manually enter the coordinates.

The input boxes are limited to numbers ±180 or ±90 via the bootstrap input component. 

I did add two English terms that would need translations. If there is a way for me to request that via crowdin, then I can do that:
```
    "defineBbox": {
      "map": "Draw bounding box on map",
      "text": "Enter coordinates"
    },
```