### PR TITLE
Make docker image build more configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
 FROM node:lts-alpine3.18 AS build-step
 ARG DYNAMIC_CONFIG=true
+ARG CATALOG_URL
+ARG PATH_PREFIX=/
 
 WORKDIR /app
 COPY package*.json ./
 RUN npm install
 COPY . .
 RUN \[ "${DYNAMIC_CONFIG}" == "true" \] && sed -i 's/<!-- <script defer="defer" src=".\/config.js"><\/script> -->/<script defer="defer" src=".\/config.js"><\/script>/g' public/index.html
-RUN npm run build
+RUN npm run build -- --catalogUrl=$CATALOG_URL --pathPrefix=$PATH_PREFIX
 
 
 FROM nginx:1-alpine-slim


### PR DESCRIPTION
The Docker file provided by the repo contains everything needed to build and run the stac browser for any need, but some build time options are not exposed.

This PR adds a way to customize `--catalogUrl` and `--pathPrefix`.

With this change an integrator does not need to fork or add a new dockerfile for using a 3rd party STAC API