### PR TITLE
Fix dynamic config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm install
 COPY . .
-RUN \[ "${DYNAMIC_CONFIG}" == "true" \] && sed -i 's/<!-- <script defer="defer" src=".\/config.js"><\/script> -->/<script defer="defer" src=".\/config.js"><\/script>/g' public/index.html
+RUN \[ "${DYNAMIC_CONFIG}" == "true" \] && sed -i 's/<!-- <script defer="defer" src="\/config.js"><\/script> -->/<script defer="defer" src="\/config.js"><\/script>/g' public/index.html
 RUN npm run build
 
 

--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta id="meta-description" name="description" content="">
-    <!-- <script defer="defer" src="./config.js"></script> -->
+    <!-- <script defer="defer" src="/config.js"></script> -->
     <title><%= htmlWebpackPlugin.options.title %></title>
   </head>
   <body>


### PR DESCRIPTION
When running Docker container at v3.1.0 (or current main branch head ae7e5cf), using a source catalog linking to sub-catalogs or sub-collections stored in subdirectories fails in the next use case.

If you access directly to nested level path, the request for dynamic configuration file `config.js` fails, because it’s not found at current path level.

Requesting `config.js` using absolute path fix this issue, finding the file always at application root path.