### PR TITLE
Serve OAF link for STAC Links

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -852,7 +852,8 @@ function getStore(config, router) {
                     url = Utils.toAbsolute(`${collectionId}/items/${item.id}`, apiCollectionsLink.href);
                   } else if (baseUrl) {
                     url = Utils.toAbsolute(`items/${item.id}`, baseUrl);
-                  } else {
+                  } 
+                  else {
                     return null;
                   }
                 }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -846,16 +846,13 @@ function getStore(config, router) {
                 }
                 else if (typeof item.id !== 'undefined') {
                   let apiCollectionsLink = cx.getters.root?.getApiCollectionsLink();
-                  if (baseUrl) {
-                    url = Utils.toAbsolute(`items/${item.id}`, baseUrl);
-                  }
-                  else if (apiCollectionsLink) {
-                    url = Utils.toAbsolute(`${collectionId}/items/${item.id}`, apiCollectionsLink.href);
-                  }
-                  else if (cx.state.catalogUrl) {
+                  if (cx.state.catalogUrl) {
                     url = Utils.toAbsolute(`collections/${collectionId}/items/${item.id}`, cx.state.catalogUrl);
-                  }
-                  else {
+                  } else if (apiCollectionsLink) {
+                    url = Utils.toAbsolute(`${collectionId}/items/${item.id}`, apiCollectionsLink.href);
+                  } else if (baseUrl) {
+                    url = Utils.toAbsolute(`items/${item.id}`, baseUrl);
+                  } else {
                     return null;
                   }
                 }


### PR DESCRIPTION
Serve the catalog url for the item if possible. By checking if there is a base URL when constructing the relative link to the item, it omits the collection name as documented in https://github.com/radiantearth/stac-browser/issues/486.