### PR TITLE
Publish docker image with /browser/ pathPrefix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,7 +79,7 @@ jobs:
           context: .
           push: true
           build-args: |
-            pathPrefix="/browser/"
+            pathPrefix=/browser/
             VERSION=${{ env.VERSION }}
             REVISION=${{ env.REVISION }}
           tags: ${{ steps.meta-prefix.outputs.tags }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,10 +37,22 @@ jobs:
           labels: |
             org.opencontainers.image.created=${{ env.COMMITED_AT }}
             org.opencontainers.image.version=v${{ env.VERSION }}
-            org.opencontainers.image.maintainer=$({github.repository_owner})
+            org.opencontainers.image.maintainer=${{github.repository_owner}}
           tags: |
             type=semver,pattern={{version}},value=v${{ env.VERSION }}
 
+      - name: Collect Docker image metadata (with /browser/ pathPrefix)
+        id: meta-prefix
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}-prefix
+          labels: |
+            org.opencontainers.image.created=${{ env.COMMITED_AT }}
+            org.opencontainers.image.version=v${{ env.VERSION }}
+            org.opencontainers.image.maintainer=${{github.repository_owner}}
+          tags: |
+            type=semver,pattern={{version}},value=v${{ env.VERSION }}
+    
       - name: Log in to the GitHub container registry
         uses: docker/login-action@v3
         with:
@@ -60,3 +72,18 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=${{ env.IMAGE_NAME }}:edge
           cache-to: type=inline
+
+      - name: Build and push Docker image (with /browser/ pathPrefix)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          build-args: |
+            pathPrefix="/browser/"
+            VERSION=${{ env.VERSION }}
+            REVISION=${{ env.REVISION }}
+          tags: ${{ steps.meta-prefix.outputs.tags }}
+          labels: ${{ steps.meta-prefix.outputs.labels }}
+          cache-from: type=registry,ref=${{ env.IMAGE_NAME }}-prefix:edge
+          cache-to: type=inline
+  


### PR DESCRIPTION
# What
Building a docker image with `pathPrefix` seems quite a common task. This PR adds another package built on every release for a docker image with `pathPrefix` set to `/browser/`. 

I'd like to receive some reaction if you think this might belong in `stac-browser` repo, and if yes, add some more docs and improve package registry metadata around this.

# Example
The results of the workflow can be seen in my fork: https://github.com/alekzvik/stac-browser/pkgs/container/stac-browser-prefix

# Notes
If the change is acceptable and you think it can live in stac-browser repo, we can change the image name or default `pathPrefix` to something else.

# Planned Improvements
- Some documentation would be good
- Better image description in the registry and explicitly stating the `pathPrefix` used is necessary