### PR TITLE
Add new option 'maxItemsPerPage'

### DIFF
--- a/config.js
+++ b/config.js
@@ -39,6 +39,7 @@ module.exports = {
     geoTiffResolution: 128,
     redirectLegacyUrls: false,
     itemsPerPage: 12,
+    maxItemsPerPage: 10000,
     defaultThumbnailSize: null,
     maxPreviewsOnMap: 50,
     crossOriginMedia: null,

--- a/config.js
+++ b/config.js
@@ -39,7 +39,7 @@ module.exports = {
     geoTiffResolution: 128,
     redirectLegacyUrls: false,
     itemsPerPage: 12,
-    maxItemsPerPage: 10000,
+    maxItemsPerPage: 1000,
     defaultThumbnailSize: null,
     maxPreviewsOnMap: 50,
     crossOriginMedia: null,

--- a/config.schema.json
+++ b/config.schema.json
@@ -169,6 +169,12 @@
       ],
       "minimum": 1
     },
+    "maxItemsPerPage": {
+      "type": [
+        "integer"
+      ],
+      "minimum": 1
+    },
     "defaultThumbnailSize": {
       "type": [
         "array",

--- a/docs/options.md
+++ b/docs/options.md
@@ -35,6 +35,7 @@ The following ways to set config options are possible:
   - [displayGeoTiffByDefault](#displaygeotiffbydefault)
   - [redirectLegacyUrls](#redirectlegacyurls)
   - [itemsPerPage](#itemsperpage)
+  - [maxItemsPerPage](#maxitemsperpage)
   - [maxPreviewsOnMap](#maxpreviewsonmap)
   - [cardViewMode](#cardviewmode)
   - [cardViewSort](#cardviewsort)
@@ -236,6 +237,10 @@ If you are updating from on old version of STAC Browser, you can set this option
 ## itemsPerPage
 
 The number of items requested and shown per page by default. Only applies to APIs that support the `limit` query parameter.
+
+## maxItemsPerPage
+
+The maximum number of items to request through the `limit` query parameter (`10000` by default).
 
 ## maxPreviewsOnMap
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -240,7 +240,7 @@ The number of items requested and shown per page by default. Only applies to API
 
 ## maxItemsPerPage
 
-The maximum number of items to request through the `limit` query parameter (`10000` by default).
+The maximum number of items to request through the `limit` query parameter (`1000` by default).
 
 ## maxPreviewsOnMap
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -240,7 +240,7 @@ The number of items requested and shown per page by default. Only applies to API
 
 ## maxItemsPerPage
 
-The maximum number of items to request through the `limit` query parameter (`1000` by default).
+The maximum number of items per page that a user can request through the `limit` query parameter (`1000` by default).
 
 ## maxPreviewsOnMap
 

--- a/src/components/SearchFilter.vue
+++ b/src/components/SearchFilter.vue
@@ -205,7 +205,6 @@ export default {
   data() {
     return Object.assign({
       results: null,
-      maxItems: 10000,
       loaded: false,
       queryables: null,
       hasAllCollections: false,
@@ -215,7 +214,7 @@ export default {
     }, getDefaults());
   },
   computed: {
-    ...mapState(['itemsPerPage', 'uiLanguage']),
+    ...mapState(['itemsPerPage', 'maxItemsPerPage', 'uiLanguage']),
     ...mapGetters(['canSearchCollections', 'supportsConformance']),
     collectionSelectOptions() {
       let taggable = !this.hasAllCollections;
@@ -280,6 +279,9 @@ export default {
       }
       const collator = new Intl.Collator(this.uiLanguage);
       return this.queryables.slice(0).sort((a, b) => collator.compare(a.title, b.title));
+    },
+    maxItems() {
+      return this.maxItemsPerPage || 10000;
     },
     datetime: {
       get() {

--- a/src/components/SearchFilter.vue
+++ b/src/components/SearchFilter.vue
@@ -281,7 +281,7 @@ export default {
       return this.queryables.slice(0).sort((a, b) => collator.compare(a.title, b.title));
     },
     maxItems() {
-      return this.maxItemsPerPage || 10000;
+      return this.maxItemsPerPage || 1000;
     },
     datetime: {
       get() {


### PR DESCRIPTION
This PR adds a new option in config.js:

```js
    maxItemsPerPage: 100,
```

which allows to define a custom value for the maximum number of items in the search filter:

![image](https://github.com/user-attachments/assets/fcc91e28-017f-4d79-8bb9-4277b83493b0)
