### PR TITLE
 Add RTL Support for Arabic Language

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,23 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" id="meta-description" content="">
-    <meta name="og:type" content="website">
-    <meta name="og:url" id="og-url" content="<%= htmlWebpackPlugin.options.url %>">
-    <meta property="og:title" id="og-title" content="<%= htmlWebpackPlugin.options.title %>"/>
-    <meta name="og:description" id="og-description" content="">
-    <meta name="og:locale" id="og-locale" content="en">
-    <meta name="og:site_name" content="<%= htmlWebpackPlugin.options.title %>">
-    <!-- <script defer="defer" src="/config.js"></script> -->
-    <title><%= htmlWebpackPlugin.options.title %></title>
-  </head>
-  <body>
-    <noscript>
-      <strong>We're sorry but STAC Browser doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
-    </noscript>
-    <div id="stac-browser"></div>
-  </body>
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" id="meta-description" content="">
+  <meta name="og:type" content="website">
+  <meta name="og:url" id="og-url" content="<%= htmlWebpackPlugin.options.url %>">
+  <meta property="og:title" id="og-title" content="<%= htmlWebpackPlugin.options.title %>" />
+  <meta name="og:description" id="og-description" content="">
+  <meta name="og:locale" id="og-locale" content="en">
+  <meta name="og:site_name" content="<%= htmlWebpackPlugin.options.title %>">
+  <!-- <script defer="defer" src="/config.js"></script> -->
+  <title>
+    <%= htmlWebpackPlugin.options.title %>
+  </title>
+
+</head>
+
+<body>
+  <noscript>
+    <strong>We're sorry but STAC Browser doesn't work properly without JavaScript enabled. Please enable it to
+      continue.</strong>
+  </noscript>
+  <div id="stac-browser"></div>
+</body>
+
 </html>

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -656,6 +656,9 @@ function getStore(config, router) {
 
         // Update stac-fields
         I18N.setLocales([uiLanguage, cx.state.fallbackLocale]);
+
+        // add rtl when user chose uiLanguage language
+       document.documentElement.setAttribute("dir", uiLanguage === "ar" ? "rtl" : "ltr");
         I18N.setTranslator(translateFields);
 
         // Execute other custom functions required to localize


### PR DESCRIPTION
This PR introduces RTL (Right-to-Left) support when the user selects Arabic (ar) as the UI language. However, since the project is built on BootstrapVue (Bootstrap 4), which lacks native RTL support, applying RTL manually caused major UI inconsistencies.

Changes Implemented:
✅ Dynamically set the dir attribute on <html> to switch between rtl and ltr
✅ Preserve BootstrapVue compatibility by keeping Bootstrap 4.
✅ Avoid Bootstrap 5 conflicts due to deep dependencies on BootstrapVue.
✅ Prevent UI breakage by not forcing manual RTL overrides that interfere with BootstrapVue’s components.

Why This Approach?
🔹 The project heavily depends on BootstrapVue, which is incompatible with Bootstrap 5.
🔹 Using Bootstrap 5 instead of BootstrapVue caused significant UI and component conflicts.
🔹 Manually forcing RTL styles led to layout issues across the app.
🔹 This solution is a practical balance—it adds RTL where needed without breaking the UI.

Future Considerations:
📌 If BootstrapVue releases an official Bootstrap 5-compatible version, upgrading would be the best long-term solution.


💡 Let me know if you need any refinements! 🚀