### PR TITLE
Improve Catalog Card Alignment and Responsiveness

### DIFF
--- a/src/components/Catalog.vue
+++ b/src/components/Catalog.vue
@@ -38,9 +38,9 @@
           variant="primary"
           :center="!isList"
         />
-        <b-card-text v-if="temporalExtent" class="datetime"
-          ><small v-html="temporalExtent"
-        /></b-card-text>
+        <b-card-text v-if="temporalExtent" class="datetime">
+          <small v-html="temporalExtent" F />
+        </b-card-text>
       </b-card-body>
       <b-card-footer>
         <slot name="footer" :data="data" />
@@ -229,7 +229,6 @@ export default {
 
     @media (min-width: 768px) {
       .catalog-card {
-
         .card-img-container {
           width: 15%;
         }

--- a/src/components/Catalog.vue
+++ b/src/components/Catalog.vue
@@ -1,17 +1,45 @@
 <template>
   <b-card no-body :class="classes" v-b-visible.400="load" :img-right="isList">
-    <b-card-img-lazy v-if="hasImage" class="thumbnail" offset="200" v-bind="thumbnail" />
+    <div class="test" v-if="hasImage">
+      <b-card-img-lazy class="thumbnail" offset="200" v-bind="thumbnail" />
+    </div>
     <b-card-body>
       <b-card-title>
         <StacLink :data="[data, catalog]" class="stretched-link" />
       </b-card-title>
-      <b-card-text v-if="data && (fileFormats.length > 0 || data.description || data.deprecated)" class="intro">
-        <b-badge v-if="data.deprecated" variant="warning" class="mr-1 mt-1 deprecated">{{ $t('deprecated') }}</b-badge>
-        <b-badge v-for="format in fileFormats" :key="format" variant="secondary" class="mr-1 mt-1 fileformat">{{ format | formatMediaType }}</b-badge>
+      <b-card-text
+        v-if="
+          data &&
+          (fileFormats.length > 0 || data.description || data.deprecated)
+        "
+        class="intro"
+      >
+        <b-badge
+          v-if="data.deprecated"
+          variant="warning"
+          class="mr-1 mt-1 deprecated"
+        >
+          {{ $t("deprecated") }}</b-badge
+        >
+        <b-badge
+          v-for="format in fileFormats"
+          :key="format"
+          variant="secondary"
+          class="mr-1 mt-1 fileformat"
+        >
+          {{ format | formatMediaType }}</b-badge
+        >
         {{ data.description | summarize }}
       </b-card-text>
-      <Keywords v-if="showKeywordsInCatalogCards && keywords.length > 0" :keywords="keywords" variant="primary" :center="!isList" />
-      <b-card-text v-if="temporalExtent" class="datetime"><small v-html="temporalExtent" /></b-card-text>
+      <Keywords
+        v-if="showKeywordsInCatalogCards && keywords.length > 0"
+        :keywords="keywords"
+        variant="primary"
+        :center="!isList"
+      />
+      <b-card-text v-if="temporalExtent" class="datetime"
+        ><small v-html="temporalExtent"
+      /></b-card-text>
     </b-card-body>
     <b-card-footer>
       <slot name="footer" :data="data" />
@@ -20,50 +48,50 @@
 </template>
 
 <script>
-import { mapState, mapGetters } from 'vuex';
-import StacFieldsMixin from './StacFieldsMixin';
-import ThumbnailCardMixin from './ThumbnailCardMixin';
-import StacLink from './StacLink.vue';
-import STAC from '../models/stac';
-import { formatMediaType, formatTemporalExtent } from '@radiantearth/stac-fields/formatters';
-import Utils from '../utils';
+import { mapState, mapGetters } from "vuex";
+import StacFieldsMixin from "./StacFieldsMixin";
+import ThumbnailCardMixin from "./ThumbnailCardMixin";
+import StacLink from "./StacLink.vue";
+import STAC from "../models/stac";
+import {
+  formatMediaType,
+  formatTemporalExtent,
+} from "@radiantearth/stac-fields/formatters";
+import Utils from "../utils";
 
 export default {
-  name: 'Catalog',
+  name: "Catalog",
   components: {
     StacLink,
-    Keywords: () => import('./Keywords.vue')
+    Keywords: () => import("./Keywords.vue"),
   },
   filters: {
-    summarize: text => Utils.summarizeMd(text, 300),
-    formatMediaType: value => formatMediaType(value, null, {shorten: true})
+    summarize: (text) => Utils.summarizeMd(text, 300),
+    formatMediaType: (value) => formatMediaType(value, null, { shorten: true }),
   },
-  mixins: [
-    ThumbnailCardMixin,
-    StacFieldsMixin({ formatTemporalExtent })
-  ],
+  mixins: [ThumbnailCardMixin, StacFieldsMixin({ formatTemporalExtent })],
   props: {
     catalog: {
       type: Object,
-      required: true
-    }
+      required: true,
+    },
   },
   computed: {
-    ...mapState(['showKeywordsInCatalogCards']),
-    ...mapGetters(['getStac']),
+    ...mapState(["showKeywordsInCatalogCards"]),
+    ...mapGetters(["getStac"]),
     classes() {
-      let classes = ['catalog-card'];
+      let classes = ["catalog-card"];
       if (!this.data) {
-        classes.push('queued');
+        classes.push("queued");
       }
       if (this.data && this.data.deprecated) {
-        classes.push('deprecated');
+        classes.push("deprecated");
       }
       if (this.hasImage) {
-        classes.push('has-thumbnail');
+        classes.push("has-thumbnail");
       }
       if (this.temporalExtent) {
-        classes.push('has-extent');
+        classes.push("has-extent");
       }
       return classes;
     },
@@ -71,10 +99,19 @@ export default {
       return this.getStac(this.catalog);
     },
     temporalExtent() {
-      if (this.data?.isCollection() && this.data.extent?.temporal?.interval.length > 0) {
+      if (
+        this.data?.isCollection() &&
+        this.data.extent?.temporal?.interval.length > 0
+      ) {
         let extent = this.data.extent.temporal.interval[0];
-        if (Array.isArray(extent) && (typeof extent[0] === 'string' || typeof extent[1] === 'string')) {
-          return this.formatTemporalExtent(this.data.extent.temporal.interval[0], true);
+        if (
+          Array.isArray(extent) &&
+          (typeof extent[0] === "string" || typeof extent[1] === "string")
+        ) {
+          return this.formatTemporalExtent(
+            this.data.extent.temporal.interval[0],
+            true
+          );
         }
       }
       return null;
@@ -87,25 +124,25 @@ export default {
     },
     keywords() {
       if (this.data) {
-        return this.data.getMetadata('keywords') || [];
+        return this.data.getMetadata("keywords") || [];
       }
       return [];
-    }
+    },
   },
   methods: {
     load(visible) {
       if (this.catalog instanceof STAC) {
         return;
       }
-      this.$store.commit(visible ? 'queue' : 'unqueue', this.catalog.href);
-    }
-  }
+      this.$store.commit(visible ? "queue" : "unqueue", this.catalog.href);
+    },
+  },
 };
 </script>
 
 <style lang="scss">
-@import '~bootstrap/scss/mixins';
-@import '../theme/variables.scss';
+@import "~bootstrap/scss/mixins";
+@import "../theme/variables.scss";
 
 #stac-browser {
   .catalog-card {
@@ -117,29 +154,36 @@ export default {
       }
     }
 
-    .card-body, .card-footer {
-      position: relative;
+    .card-body,
+    .card-footer {
+      // position: relative;
     }
     .card-footer:empty {
       display: none;
     }
     .card-title {
       margin-bottom: 0.5rem;
+      -webkit-line-clamp: 2;
     }
     .intro {
-      display: -webkit-box;
       -webkit-line-clamp: 3;
+    }
+    .intro,
+    .card-title {
+      display: -webkit-box;
       -webkit-box-orient: vertical;
       overflow: hidden;
       overflow-wrap: anywhere;
       text-align: left;
+      background-color: greenyellow;
     }
+
     &.has-extent {
       .intro {
         margin-bottom: 0.5rem;
       }
     }
-    .datetime {
+        .datetime {
       color: map-get($theme-colors, "secondary");
     }
     .badge.deprecated {
@@ -176,17 +220,29 @@ export default {
       margin-top: 0.5em 0;
       text-align: center;
 
-      &.queued {
-        min-height: 10rem;
+      // &.queued {
+      //   min-height: 10rem;
+      // }
+      .test {
+        background-color: rgb(204, 204, 204);
+        width: 100%;
+        height: 220px;
       }
       .card-img {
-        width: auto;
-        height: auto;
-        max-width: 100%;
-        max-height: 300px;
+        width: 100%;
+        height: 100%;
+        background-color: rgb(0, 255, 21);
       }
-      .card-title {
-        text-align: center;
+
+      .card-body {
+        // position: relative;
+        background-color: rgb(241, 180, 180);
+        height: 180px;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-evenly;
+        text-align: start;
+        padding: 8px
       }
     }
   }

--- a/src/components/Catalog.vue
+++ b/src/components/Catalog.vue
@@ -1,49 +1,51 @@
 <template>
   <b-card no-body :class="classes" v-b-visible.400="load" :img-right="isList">
-    <div class="test" v-if="hasImage">
+    <div class="card-img-container" v-if="hasImage">
       <b-card-img-lazy class="thumbnail" offset="200" v-bind="thumbnail" />
     </div>
-    <b-card-body>
-      <b-card-title>
-        <StacLink :data="[data, catalog]" class="stretched-link" />
-      </b-card-title>
-      <b-card-text
-        v-if="
-          data &&
-          (fileFormats.length > 0 || data.description || data.deprecated)
-        "
-        class="intro"
-      >
-        <b-badge
-          v-if="data.deprecated"
-          variant="warning"
-          class="mr-1 mt-1 deprecated"
+    <div class="card-content">
+      <b-card-body>
+        <b-card-title>
+          <StacLink :data="[data, catalog]" class="stretched-link" />
+        </b-card-title>
+        <b-card-text
+          v-if="
+            data &&
+            (fileFormats.length > 0 || data.description || data.deprecated)
+          "
+          class="intro"
         >
-          {{ $t("deprecated") }}</b-badge
-        >
-        <b-badge
-          v-for="format in fileFormats"
-          :key="format"
-          variant="secondary"
-          class="mr-1 mt-1 fileformat"
-        >
-          {{ format | formatMediaType }}</b-badge
-        >
-        {{ data.description | summarize }}
-      </b-card-text>
-      <Keywords
-        v-if="showKeywordsInCatalogCards && keywords.length > 0"
-        :keywords="keywords"
-        variant="primary"
-        :center="!isList"
-      />
-      <b-card-text v-if="temporalExtent" class="datetime"
-        ><small v-html="temporalExtent"
-      /></b-card-text>
-    </b-card-body>
-    <b-card-footer>
-      <slot name="footer" :data="data" />
-    </b-card-footer>
+          <b-badge
+            v-if="data.deprecated"
+            variant="warning"
+            class="mr-1 mt-1 deprecated"
+          >
+            {{ $t("deprecated") }}</b-badge
+          >
+          <b-badge
+            v-for="format in fileFormats"
+            :key="format"
+            variant="secondary"
+            class="mr-1 mt-1 fileformat"
+          >
+            {{ format | formatMediaType }}</b-badge
+          >
+          {{ data.description | summarize }}
+        </b-card-text>
+        <Keywords
+          v-if="showKeywordsInCatalogCards && keywords.length > 0"
+          :keywords="keywords"
+          variant="primary"
+          :center="!isList"
+        />
+        <b-card-text v-if="temporalExtent" class="datetime"
+          ><small v-html="temporalExtent"
+        /></b-card-text>
+      </b-card-body>
+      <b-card-footer>
+        <slot name="footer" :data="data" />
+      </b-card-footer>
+    </div>
   </b-card>
 </template>
 
@@ -156,7 +158,7 @@ export default {
 
     .card-body,
     .card-footer {
-      // position: relative;
+      position: relative;
     }
     .card-footer:empty {
       display: none;
@@ -175,7 +177,6 @@ export default {
       overflow: hidden;
       overflow-wrap: anywhere;
       text-align: left;
-      background-color: greenyellow;
     }
 
     &.has-extent {
@@ -183,7 +184,7 @@ export default {
         margin-bottom: 0.5rem;
       }
     }
-        .datetime {
+    .datetime {
       color: map-get($theme-colors, "secondary");
     }
     .badge.deprecated {
@@ -195,54 +196,73 @@ export default {
       box-sizing: border-box;
       margin: 0.5em 0;
       display: flex;
-
-      .card-img-right {
-        min-height: 100px;
+      max-height: 170px;
+      overflow: hidden;
+      align-items: center;
+      .card-content {
+        width: 65%;
+        flex-grow: 1;
+      }
+      .card-img-container {
+        width: 35%;
         height: 100%;
-        max-height: 8.5rem;
-        max-width: 33%;
-        object-fit: contain;
-        object-position: right;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+
+        .card-img-right {
+          width: auto;
+          height: auto;
+          max-width: 100%;
+          max-height: 100%;
+          object-position: center;
+        }
       }
       .card-footer {
-        min-width: 175px;
-        max-width: 175px;
+        width: 175px;
         border-top: 0;
       }
       .intro {
         -webkit-line-clamp: 2;
       }
     }
+
+    @media (min-width: 768px) {
+      .catalog-card {
+
+        .card-img-container {
+          width: 15%;
+        }
+
+        .card-content {
+          width: 85%;
+        }
+      }
+    }
   }
   .card-columns {
     .catalog-card {
       box-sizing: border-box;
-      margin-top: 0.5em 0;
       text-align: center;
 
-      // &.queued {
-      //   min-height: 10rem;
-      // }
-      .test {
-        background-color: rgb(204, 204, 204);
+      .card-img-container {
+        background-color: #fff;
         width: 100%;
         height: 220px;
-      }
-      .card-img {
-        width: 100%;
-        height: 100%;
-        background-color: rgb(0, 255, 21);
+        .card-img {
+          width: auto;
+          max-width: 100%;
+          height: 100%;
+        }
       }
 
       .card-body {
-        // position: relative;
-        background-color: rgb(241, 180, 180);
         height: 180px;
         display: flex;
         flex-direction: column;
         justify-content: space-evenly;
         text-align: start;
-        padding: 8px
+        padding: 8px;
       }
     }
   }

--- a/src/views/SelectDataSource.vue
+++ b/src/views/SelectDataSource.vue
@@ -5,9 +5,11 @@
         id="select" :label="$t('index.specifyCatalog')" label-for="url"
         :invalid-feedback="error" :state="valid"
       >
-        <b-form-input id="url" type="url" :value="url" @input="setUrl" placeholder="https://..." />
+        <div class="form-action">
+          <b-form-input id="url" type="url" :value="url" @input="setUrl" placeholder="https://..." />
+          <b-button type="submit" variant="primary">{{ $t('index.load') }}</b-button>
+        </div>
       </b-form-group>
-      <b-button type="submit" variant="primary">{{ $t('index.load') }}</b-button>
     </b-form>
     <hr v-if="stacIndex.length > 0">
     <b-form-group v-if="stacIndex.length > 0" class="stac-index">
@@ -159,6 +161,11 @@ export default {
         }
       }
     }
+  }
+
+  .form-action {
+    display: flex;
+    gap: 10px;
   }
 }
 </style>


### PR DESCRIPTION
In the STAC Browser, catalog cards were uneven and not well-aligned, making the layout look unorganized. While working on a fix, I realized that the current design works well since some catalog entries don’t always require an image or description. However, I focused on improving the layout consistency by ensuring all cards have the same height, refining image alignment, and enhancing the responsive display for a more polished user experience

- before 
![Screenshot 2025-03-10 224405](https://github.com/user-attachments/assets/3544ab19-ac37-4372-b8a2-5dc87beaacf9)
![Screenshot 2025-03-10 224427](https://github.com/user-attachments/assets/8757226a-0140-4cb3-b777-8cac35a2acdb)
![Screenshot 2025-03-10 224306](https://github.com/user-attachments/assets/353b61db-31c8-4d46-a943-d1f5447a961a)
![Screenshot 2025-03-10 224957](https://github.com/user-attachments/assets/2c909de5-b913-48d9-98b3-9bc680134c5d)

- after
![Screenshot 2025-03-10 224807](https://github.com/user-attachments/assets/6803169e-9874-4dc7-871e-5da288c27991)
![Screenshot 2025-03-10 224014](https://github.com/user-attachments/assets/95bc8867-3649-4c46-9b03-3ef927dbeb24)
![Screenshot 2025-03-10 224117](https://github.com/user-attachments/assets/2335f7c3-d29c-4ecd-8c0a-1c6e4df5d665)
![Screenshot 2025-03-10 223426](https://github.com/user-attachments/assets/5a65d8bc-fbd2-4009-9a22-c9a2cc4a01fd)
![Screenshot 2025-03-10 224040](https://github.com/user-attachments/assets/4e6164aa-7b5f-43c4-b2d0-571c49d22f5c)
