### PR TITLE
New option to setup default extent area for statial query

### DIFF
--- a/config.js
+++ b/config.js
@@ -45,5 +45,7 @@ module.exports = {
     requestQueryParameters: {},
     socialSharing: ['email', 'bsky', 'mastodon', 'x'],
     preprocessSTAC: null,
-    authConfig: null
+    authConfig: null,
+    // defaultSearchExtent e.g. [12.227593034455793, 41.78656913683952, 12.652310726657447, 42.02970865107619]
+    defaultSearchExtent: null,
 };

--- a/src/components/SearchFilter.vue
+++ b/src/components/SearchFilter.vue
@@ -27,8 +27,8 @@
         </b-form-group>
 
         <b-form-group v-if="canFilterExtents" class="filter-bbox" :label="$t('search.spatialExtent')" :label-for="ids.bbox">
-          <b-form-checkbox :id="ids.bbox" v-model="provideBBox" value="1">{{ $t('search.filterBySpatialExtent') }}</b-form-checkbox>
-          <MapSelect class="mb-4" v-if="provideBBox" v-model="query.bbox" :stac="stac" />
+          <b-form-checkbox :id="ids.bbox" v-model="provideBBox" checked="provideBBox">{{ $t('search.filterBySpatialExtent') }}</b-form-checkbox>
+          <MapSelect class="mb-4" v-if="provideBBox" v-model="query.bbox" :stac="stac" :initExtent="defaultExtent" />
         </b-form-group>
 
         <b-form-group v-if="conformances.CollectionIdFilter" class="filter-collection" :label="$tc('stacCollection', collections.length)" :label-for="ids.collections">
@@ -153,7 +153,7 @@ function getDefaults() {
   return {
     sortOrder: 1,
     sortTerm: null,
-    provideBBox: false,
+    provideBBox: true,
     // Store previous bbox so that it survives when the map is temporarily hidden
     bbox: null,
     query: getQueryDefaults(),
@@ -295,7 +295,7 @@ export default {
       set(val) {
         this.query.datetime = Array.isArray(val) ? val.map(d => Utils.dateToUTC(d)) : null;
       }
-    }
+    },
   },
   watch: {
     parent: {

--- a/src/components/SearchFilter.vue
+++ b/src/components/SearchFilter.vue
@@ -217,7 +217,7 @@ export default {
   },
   computed: {
     ...mapState(['itemsPerPage', 'maxItemsPerPage', 'uiLanguage']),
-    ...mapGetters(['canSearchCollections', 'supportsConformance']),
+    ...mapGetters(['canSearchCollections', 'supportsConformance', 'defaultSearchExtent']),
     collectionSelectOptions() {
       let taggable = !this.hasAllCollections;
       let isResult = this.collections.length > 0 && !this.hasAllCollections;
@@ -257,6 +257,9 @@ export default {
         return this.parent;
       }
       return null;
+    },
+    defaultExtent() {
+      return this.query?.bbox? this.query.bbox : this.defaultSearchExtent;
     },
     andOrOptions() {
       return [

--- a/src/components/maps/MapSelect.vue
+++ b/src/components/maps/MapSelect.vue
@@ -46,7 +46,7 @@ export default {
       type: Object,
       default: null
     },
-    value: {
+    initExtent: {
       type: Array,
       default: null
     },
@@ -58,8 +58,8 @@ export default {
   data() {
     return {
       crs: 'EPSG:4326',
-      extent: this.value,
-      dragging: false
+      extent: this.initExtent,
+      dragging: true
     };
   },
   computed: {

--- a/src/components/maps/MapSelect.vue
+++ b/src/components/maps/MapSelect.vue
@@ -49,6 +49,10 @@ export default {
     value: {
       type: Array,
       default: null
+    },
+    value: {
+      type: Array,
+      default: null
     }
   },
   data() {
@@ -86,6 +90,9 @@ export default {
   methods: {
     async initMap() {
       this.map = null;
+      if (this.initExtent) {
+        this.extent = this.initExtent;
+      }
 
       await this.createMap(this.$refs.map, this.stac, true);
 
@@ -144,8 +151,10 @@ export default {
         }
       }
       if (extent) {
+        this.map.updateSize();
         this.map.getView().fit(extent, { padding: [50,50,50,50] });
       }
+
     },
     addMask(stac) {
       // Darken areas outside of the available area

--- a/src/locales/it/texts.json
+++ b/src/locales/it/texts.json
@@ -156,7 +156,17 @@
       "label": "i",
       "collapseLabel": "✕"
     },
+    "bboxSelect": {
+      "add": "Cliccare sulla mappa per aggiungere un box di selezione.",
+      "remove": "Cliccare dentro il box per eliminarlo."
+    },
     "close": "Chiudi",
+    "fit": "Adatta alla estensione",
+    "location": {
+      "description": "Vai alla tua posizione attuale"
+    },
+    "nobasemap": "Mappa base non disponibile.",
+    "nodata": "Indormazione spaziale mancante nei metadati.",
     "zoom": {
       "in": {
         "description": "Zoom avanti",

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -63,6 +63,9 @@ function getStore(config, router) {
       uiLanguage: config.locale
     }),
     getters: {
+      defaultSearchExtent: state => {
+        return state.defaultSearchExtent? state.defaultSearchExtent : null;
+      },
       loading: state => !state.url || !state.data || state.database[state.url] instanceof Loading,
       getApiItemsLoading: state => data => {
         let id = '';


### PR DESCRIPTION
This PR add the following features:
A) add a config.js options:
```
   // defaultSearchExtent e.g. [12.227593034455793, 41.78656913683952, 12.652310726657447, 42.02970865107619]
    defaultSearchExtent: null,
```
B) defaultSearchExtent is used to init extent of the spatial query option in /search endpoint.
C) enable by default spatial query

This PR has been sponsored by GeoBeyond (http://www.geobeyond.it/) for the project Aerofototeca of the Rome monicipality.