### PR TITLE
Independent item and collection search

### DIFF
--- a/src/components/StacHeader.vue
+++ b/src/components/StacHeader.vue
@@ -126,7 +126,7 @@ export default {
       }
       let searchLink;
       if (this.data instanceof STAC && !this.data.equals(this.root)) {
-        searchLink = this.data.getSearchLink();
+        searchLink = this.data.getSearchLink() || this.data.getApiCollectionsLink();
       }
       if (searchLink) {
         return `/search${this.data.getBrowserPath()}`;


### PR DESCRIPTION
This is a possible solution for independent item and collection search as mentioned in [issue 599](https://github.com/radiantearth/stac-browser/issues/599) for NASA ESDIS (I am one of the interns that Doug Newman mentioned). We believe the main issue we were facing boils down to how the search button link for a catalog page is generated.

Initially, search functionality for our ALL provider was not supported when accessing the search page from the [provider page](https://radiantearth.github.io/stac-browser/#/external/cmr.earthdata.nasa.gov/stac/ALL) in CMR STAC. We found that directly accessing the [search page](https://radiantearth.github.io/stac-browser/#/search/external/cmr.earthdata.nasa.gov/stac/ALL) correctly allows for independent collection search (even with the item search conformance classes, but we do intend to remove them).

The issue was that the search button link on the catalog page was falling back to the root catalog search. `searchLink` was set to null because the rel=search links for item search were removed in CMR STAC. Adding `|| this.data.getApiCollectionsLink()` provides the correct search link when only collection search is supported (taking inspiration from lines 130-135 in `src/views/Search.vue`).

Please let me know if we have any misconceptions, and any feedback would be appreciated!