### PR TITLE
Fixing issue with basic http authentication detection

### DIFF
--- a/src/components/auth/utils.js
+++ b/src/components/auth/utils.js
@@ -22,7 +22,7 @@ export default class AuthUtils {
     }
     switch(method.type) {
       case 'http':
-        return (method.schema === 'basic');
+        return (method.scheme === 'basic');
       case 'apiKey':
         return (method.in === 'header' || method.in === 'query');
       case 'openIdConnect':


### PR DESCRIPTION
The HTTP Basic authentication is not correctly identified : when setting {type: http, scheme: basic} in the config file as given in the options.md file, it says the HTTP Basic is not supported.

This pull fixes it.