### PR TITLE
Distribute a portable and pre-compiled version with releases

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -1,0 +1,38 @@
+name: Dist
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  build-and-attach-release:
+    runs-on: ubuntu-latest
+    name: Build app and upload to release
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build app
+        run: npm run build
+
+      - name: Archive build output
+        run: |
+          cd dist
+          zip -r ../dist.zip .
+
+      - name: Upload build to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/config.js
+++ b/config.js
@@ -32,7 +32,7 @@ module.exports = {
     buildTileUrlTemplate: ({href, asset}) => "https://tiles.rdnt.io/tiles/{z}/{x}/{y}@2x?url=" + encodeURIComponent(href),
     stacProxyUrl: null,
     pathPrefix: "./",
-    historyMode: "history",
+    historyMode: "hash",
     cardViewMode: "cards",
     cardViewSort: "asc",
     showKeywordsInItemCards: false,

--- a/config.js
+++ b/config.js
@@ -31,7 +31,7 @@ module.exports = {
     displayGeoTiffByDefault: false,
     buildTileUrlTemplate: ({href, asset}) => "https://tiles.rdnt.io/tiles/{z}/{x}/{y}@2x?url=" + encodeURIComponent(href),
     stacProxyUrl: null,
-    pathPrefix: "/",
+    pathPrefix: "./",
     historyMode: "history",
     cardViewMode: "cards",
     cardViewSort: "asc",

--- a/public/index.html
+++ b/public/index.html
@@ -11,7 +11,7 @@
     <meta name="og:description" id="og-description" content="">
     <meta name="og:locale" id="og-locale" content="en">
     <meta name="og:site_name" content="<%= htmlWebpackPlugin.options.title %>">
-    <!-- <script defer="defer" src="/config.js"></script> -->
+    <script src="config.js"></script>
     <title><%= htmlWebpackPlugin.options.title %></title>
   </head>
   <body>


### PR DESCRIPTION
Hey !

First: thanks for stac-browser, pretty neat project !!

This PR adds a compiled archive of the app to releases so deploying stac-browser becomes as easy as unzip the archive in your webroot ! It's much less involved and more portable than Docker or node compilation, and aligns well with fully static STAC catalogues, thus would make adoption of this package much easier.

It didnt work out of the box due to:

- stac-browser assumes the files are at the root of the webserver (assets are loaded with `src="/js/app.49a81c21.js"`)
- there seem to be no clean way to override `catalogUrl` (I see a `config.js` file got generated in the dist folder, but it doesn't seem to get called ? it works if I manually add `<script src="/config.js"></script>` in index.html)

I changed the following so it works:
- load `config.js` in index.html to allow changing settings at runtime
- set pathPrefix to `./` instead of `/`
- swtich to hash location instead of urls, otherwise loading of assets fails in subpages.

Unfortunately I don't know enough about modern javascript development (and nothing about Vue) to make it work with less invasive changes... Unsure you'll be willing to merge that ? Or are there alternative implementations that would make more sense (e.g. dynamically resolve relative links) ?

Ideally it should also be distributed through CDNs (but unsure how that's setup in the npm ecosystem), this way it could even be adopted with no download.

Note: you can see the generated dist.zip on my fork: https://github.com/olivierdalang/stac-browser/releases/latest

Cheers,

Olivier

