### PR TITLE
fix unresolved HTML sources in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ COPY ./config.schema.json /etc/nginx/conf.d/config.schema.json
 COPY --from=build-step /app/dist /usr/share/nginx/html
 COPY --from=build-step /app/docker/default.conf /etc/nginx/conf.d/default.conf
 RUN sed -i "s|<pathPrefix>|${pathPrefix}|" /etc/nginx/conf.d/default.conf
+RUN ln -s /usr/share/nginx/html /etc/nginx/html
 
 EXPOSE 8080
 


### PR DESCRIPTION
I am not sure if the issue is only related to build with `pathPrefix` or not, but it seems HTML files cannot be resolved by Nginx. By adding the symlink, everything resolves transparently.

Building the https://github.com/radiantearth/stac-browser/tree/main and deploying it, I am unable to make the browser work. 

However, I use this equivalent patch, and everything resolves correctly: https://github.com/radiantearth/stac-browser/compare/main...crim-ca:stac-browser:master