### PR TITLE
Run container as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,19 +13,23 @@ RUN \[ "${DYNAMIC_CONFIG}" == "true" \] && sed -i "s|<!-- <script defer=\"defer\
 RUN npm run build -- --historyMode="${historyMode}" --pathPrefix="${pathPrefix}"
 
 
-FROM nginx:1-alpine-slim
+FROM nginxinc/nginx-unprivileged:1-alpine
 ARG pathPrefix
 
-RUN apk add jq pcre-tools
+USER root
+RUN apk add --no-cache jq pcre-tools
 
 COPY ./config.schema.json /etc/nginx/conf.d/config.schema.json
 COPY --from=build-step /app/dist /usr/share/nginx/html
 COPY --from=build-step /app/docker/default.conf /etc/nginx/conf.d/default.conf
-RUN sed -i "s|<pathPrefix>|${pathPrefix}|" /etc/nginx/conf.d/default.conf
+ADD docker/docker-entrypoint.sh /docker-entrypoint.d/40-stac-browser-entrypoint.sh
+
+RUN sed -i "s|<pathPrefix>|${pathPrefix}|" /etc/nginx/conf.d/default.conf && \
+    chown -R nginx:nginx /usr/share/nginx/html && \
+    chmod +x /docker-entrypoint.d/40-stac-browser-entrypoint.sh
 
 EXPOSE 8080
 
 STOPSIGNAL SIGTERM
 
-# override entrypoint, which calls nginx-entrypoint underneath
-ADD docker/docker-entrypoint.sh /docker-entrypoint.d/40-stac-browser-entrypoint.sh
+USER nginx


### PR DESCRIPTION
Following wide best practices, containers should run with a non-root user. This PR suggest switching to the _unpriviledged_ nginx base image.