### PR TITLE
Maintain card width from stretching to fill the entire grid width.

### DIFF
--- a/src/theme/page.scss
+++ b/src/theme/page.scss
@@ -318,7 +318,7 @@ body {
 
   .card-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
     grid-auto-rows: min-content;
     // The layout uses margin-bottom instead of row-gap (on .catalog-grid), because
     // the .card-img-wrapper is supposed to collapse to 0px height when there are no


### PR DESCRIPTION
## Before
<img width="1889" height="458" alt="Screenshot 2026-02-10 at 10 39 32" src="https://github.com/user-attachments/assets/ee109153-54f9-45cc-8f5a-d5965c0b070e" />

<img width="1905" height="416" alt="Screenshot 2026-02-10 at 10 40 01" src="https://github.com/user-attachments/assets/eb90a3f1-7979-4e54-b3c9-80b0fa379afa" />

## After
<img width="1906" height="511" alt="Screenshot 2026-02-10 at 10 41 04" src="https://github.com/user-attachments/assets/7dc20cdd-57b7-436e-8883-314fdf369224" />

<img width="1903" height="469" alt="Screenshot 2026-02-10 at 10 41 27" src="https://github.com/user-attachments/assets/7ef1ec38-e366-4a04-a91a-2f2758eb4c64" />
