### PR TITLE
Swap unplugin-icon config from bootstrap to mdi.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.2",
-        "@iconify-json/bi": "^1.2.6",
+        "@iconify-json/mdi": "^1.2.3",
         "@playwright/test": "^1.57.0",
         "@vitejs/plugin-vue": "^6.0.1",
         "@vue/compiler-sfc": "^3.5.22",
@@ -898,12 +898,12 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@iconify-json/bi": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@iconify-json/bi/-/bi-1.2.7.tgz",
-      "integrity": "sha512-IPz8WNxmLkH1I9msl+0Q4OnmjjvP4uU0Z61a4i4sqonB6vKSbMGUWuGn8/YuuszlReVj8rf+3gNv5JU8Xoljyg==",
+    "node_modules/@iconify-json/mdi": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@iconify-json/mdi/-/mdi-1.2.3.tgz",
+      "integrity": "sha512-O3cLwbDOK7NNDf2ihaQOH5F9JglnulNDFV7WprU2dSoZu3h3cWH//h74uQAB87brHmvFVxIOkuBX2sZSzYhScg==",
       "dev": true,
-      "license": "MIT",
+      "license": "Apache-2.0",
       "dependencies": {
         "@iconify/types": "*"
       }

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",
-    "@iconify-json/bi": "^1.2.6",
+    "@iconify-json/mdi": "^1.2.3",
     "@playwright/test": "^1.57.0",
     "@vitejs/plugin-vue": "^6.0.1",
     "@vue/compiler-sfc": "^3.5.22",

--- a/src/StacBrowser.vue
+++ b/src/StacBrowser.vue
@@ -97,8 +97,8 @@ import { mapMutations, mapActions, mapGetters, mapState } from 'vuex';
 import CONFIG from './config';
 
 // Import icons needed for dynamic component usage
-import BIconLock from '~icons/bi/lock';
-import BIconUnlock from '~icons/bi/unlock';
+import MdiLock from '~icons/mdi/lock-outline';
+import MdiUnlock from '~icons/mdi/lock-open-variant-outline';
 
 import ErrorAlert from './components/ErrorAlert.vue';
 import StacLink from './components/StacLink.vue';
@@ -135,8 +135,8 @@ export default defineComponent({
   name: 'StacBrowser',
   components: {
     Authentication,
-    BIconLock,
-    BIconUnlock,
+    MdiLock,
+    MdiUnlock,
     BPopover: defineAsyncComponent(() => import('bootstrap-vue-next').then(m => m.BPopover)),
     ErrorAlert,
     LanguageChooser: defineAsyncComponent(() => import('./components/LanguageChooser.vue')),
@@ -183,7 +183,7 @@ export default defineComponent({
       return this.$route.name === 'select';
     },
     authIcon() {
-      return this.isLoggedIn ? BIconUnlock : BIconLock;
+      return this.isLoggedIn ? MdiUnlock : MdiLock;
     },
     authTitle() {
       return this.authMethod.getButtonTitle();

--- a/src/StacBrowser.vue
+++ b/src/StacBrowser.vue
@@ -10,10 +10,10 @@
           <nav class="actions navigation">
             <b-button-group v-if="canSearch || !isServerSelector">
               <b-button v-if="!isServerSelector" variant="primary" size="sm" :title="$t('browse')" @click="sidebar = !sidebar">
-                <b-icon-list /><span class="button-label">{{ $t('browse') }}</span>
+                <mdi-menu /><span class="button-label">{{ $t('browse') }}</span>
               </b-button>
               <b-button v-if="canSearch" variant="primary" size="sm" :to="searchBrowserLink" :title="$t('search.title')" :pressed="isSearchPage">
-                <b-icon-search /><span class="button-label">{{ $t('search.title') }}</span>
+                <mdi-magnify /><span class="button-label">{{ $t('search.title') }}</span>
               </b-button>
             </b-button-group>
           </nav>

--- a/src/components/LanguageChooser.vue
+++ b/src/components/LanguageChooser.vue
@@ -1,10 +1,10 @@
 <template>
   <b-dropdown size="sm" variant="primary" right :title="$t('source.language.switch')">
     <template #button-content>
-      <b-icon-flag /><span class="button-label">{{ $t('source.language.label', {currentLanguage}) }}</span>
+      <mdi-translate /><span class="button-label">{{ $t('source.language.label', {currentLanguage}) }}</span>
     </template>
     <b-dropdown-item v-for="l of languages" :key="l.code" class="lang-item" @click="setLocale(l.code)">
-      <b-icon-check :class="{hide: currentLocale !== l.code}" />
+      <mdi-check :class="{hide: currentLocale !== l.code}" />
       <span class="title">
         <span :lang="l.code">{{ l.native }}</span>
         <template v-if="l.global && l.global !== l.native"> / <span lang="en">{{ l.global }}</span></template>

--- a/src/components/SearchBox.vue
+++ b/src/components/SearchBox.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="vue-component search-box">
-    <b-icon-search class="icon" />
+    <mdi-magnify class="icon" />
     <b-form-input type="search" v-model.trim="searchTerm" :placeholder="placeholder || $t('search.placeholder')" />
   </div>
 </template>

--- a/vite.config.js
+++ b/vite.config.js
@@ -121,9 +121,9 @@ export default defineConfig(({ mode }) => ({
         }), // Auto-register Bootstrap components
         IconsResolver({
           prefix: false,
-          enabledCollections: ["bi"],
+          enabledCollections: ["mdi"],
           alias: {
-            "b-icon": "bi",
+            "mdi-icon": "mdi",
           },
           customCollections: ["share"],
         }),


### PR DESCRIPTION
- Only a small number of icons are replaced yet (`<mdi-`) all the others needs to be replaced (`<b-icon`) in the templates. There are also some that are imported and used in scripts which need to be updated.
- Run npm install to have the mdi package install.