### PR TITLE
Revert to old asset styling

### DIFF
--- a/src/components/Asset.vue
+++ b/src/components/Asset.vue
@@ -1,5 +1,11 @@
 <template>
-  <b-accordion-item :id="uid" class="asset expandable-card" v-model="expanded" @update:model-value="collapseToggled">
+  <b-accordion-item
+    :id="uid"
+    v-model="expanded"
+    class="asset"
+    body-class="asset-body"
+    @update:model-value="collapseToggled"
+  >
     <template #title>
       <span class="chevron" aria-hidden="true">
         <b-icon-chevron-down v-if="expanded" />
@@ -19,14 +25,16 @@
     </template>
    
     <template v-if="hasAlternatives">
-      <b-tabs content-class="mt-3" lazy>
-        <b-tab :title="asset['alternate:name'] || $t('assets.alternate.main')" active>
-          <AssetAlternative :asset="asset" :shown="shown" hasAlternatives @show="show" />
-        </b-tab>
-        <b-tab v-for="(altAsset, key) in alternatives" :title="altAsset['alternate:name'] || key" :key="key">
-          <AssetAlternative :asset="altAsset" :shown="shown" hasAlternatives @show="show" />
-        </b-tab>
-      </b-tabs>
+      <b-card no-body class="border-0 rounded-0">
+        <b-tabs lazy card>
+          <b-tab :title="asset['alternate:name'] || $t('assets.alternate.main')" active no-body>
+            <AssetAlternative :asset="asset" :shown="shown" hasAlternatives @show="show" />
+          </b-tab>
+          <b-tab v-for="(altAsset, key) in alternatives" :title="altAsset['alternate:name'] || key" :key="key" no-body>
+            <AssetAlternative :asset="altAsset" :shown="shown" hasAlternatives @show="show" />
+          </b-tab>
+        </b-tabs>
+      </b-card>
     </template>
     <AssetAlternative v-else :asset="asset" :shown="shown" @show="show" />
   </b-accordion-item>
@@ -39,12 +47,13 @@ import { mapState } from 'vuex';
 import StacFieldsMixin from './StacFieldsMixin';
 import Utils from '../utils';
 import { Asset } from 'stac-js';
-import { BTab, BTabs, BAccordionItem } from 'bootstrap-vue-next';
+import { BCard, BTab, BTabs, BAccordionItem } from 'bootstrap-vue-next';
 
 export default {
   name: 'Asset',
   components: {
     AssetAlternative: defineAsyncComponent(() => import('./AssetAlternative.vue')),
+    BCard,
     BTab,
     BTabs,
     BAccordionItem
@@ -169,15 +178,16 @@ export default {
 
 <style lang="scss">
 #stac-browser .asset {
+  .asset-body {
+    padding: 0;
+  }
+
   .metadata {
     .card-columns {
       column-count: 1;
     }
     .card {
       border: 0;
-    }
-    .card-body {
-      padding: 0;
     }
   }
 }

--- a/src/components/AssetAlternative.vue
+++ b/src/components/AssetAlternative.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="asset-alternative">
     <h4 class="mb-4" v-html="fileFormat" />
     <HrefActions isAsset :data="asset" :shown="shown" @show="show" :auth="auth" />
     <div class="mt-4" v-if="asset.description">
@@ -118,3 +118,9 @@ export default {
   }
 };
 </script>
+
+<style lang="scss" scoped>
+.asset-alternative {
+  padding: 1rem;
+}
+</style>

--- a/src/components/Assets.vue
+++ b/src/components/Assets.vue
@@ -3,7 +3,7 @@
     <h2 v-if="displayTitle">{{ displayTitle }}</h2>
     <b-accordion>
       <Asset
-        v-for="asset in assets" :asset="asset" :expand="expand" :context="context"
+        v-for="asset in assets" :asset="asset" :expand="expand"
         :definition="definition" :shown="shownKeys.includes(asset.getKey())"
         :key="asset.getKey()" @show="show"
       />

--- a/src/theme/page.scss
+++ b/src/theme/page.scss
@@ -174,6 +174,11 @@ body {
             &:last-of-type {
               margin-bottom: 0.5rem;
             }
+
+            > button {
+              width: 100%;
+              text-align: left;
+            }
           }
         }
       }


### PR DESCRIPTION
<img width="658" height="233" alt="grafik" src="https://github.com/user-attachments/assets/c5cf67d2-5039-4325-8ef9-79c3f359ede0" />

changed back to

<img width="656" height="334" alt="grafik" src="https://github.com/user-attachments/assets/1966c07c-7b2c-4f79-bd02-43c72977b7d8" />

and updated the thumbnail/map tabs to be 100% width again.
