### PR TITLE
fix(docker): update runtime config paths for v5 file structure.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm install
 COPY . .
-RUN \[ "${DYNAMIC_CONFIG}" == "true" \] && sed -i "s|<!-- <script defer=\"defer\" src=\"/config.js\"></script> -->|<script defer=\"defer\" src=\"${pathPrefix}config.js\"></script>|g" public/index.html
+RUN \[ "${DYNAMIC_CONFIG}" == "true" \] && sed -i "s|<!-- <script defer=\"defer\" src=\"/runtime-config.js\"></script> -->|<script defer=\"defer\" src=\"${pathPrefix}runtime-config.js\"></script>|g" index.html
 RUN npm run build
 
 

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -89,4 +89,4 @@ env -0 | cut -f1 -d= | tr '\0' '\n' | grep "^SB_" | {
         echo ","
     done
     echo "}"
-} > /usr/share/nginx/html/config.js
+} > /usr/share/nginx/html/runtime-config.js

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -72,7 +72,7 @@ So, essentially, in the end you get an nginx instance that serves static files.
 
 1. [Dockerfile](../Dockerfile) - contains information on how to build the image.
 2. [docker/default.conf](../docker/default.conf) - nginx configuration template, where `<pathPrefix>` is replaced during build.
-3. [docker/docker-entrypoint.sh](../docker/docker-entrypoint.sh) - a start script to read the passed variables and produce the `config.js` file.
+3. [docker/docker-entrypoint.sh](../docker/docker-entrypoint.sh) - a start script to read the passed variables and produce the `runtime-config.js` file.
 
 ## FAQ
 
@@ -82,4 +82,4 @@ You can not. You need to build your own image because `pathPrefix` is a build-on
 
 > How do I specify `buildTileUrlTemplate` via docker env?
 
-You can not. Consider modifying the dockerfile and using a custom `config.js` file
+You can not. Consider modifying the dockerfile and using a custom `config.js` file (or `runtime-config.js` for runtime configuration)

--- a/docs/options.md
+++ b/docs/options.md
@@ -10,8 +10,8 @@ The following ways to set config options are possible:
 - Set **environment variables**, all options need a `SB_` prefix.
   So you could for example set the catalog URL via the environment variable `SB_catalogUrl`.
 - Optionally, you can also set options after the build, basically **at "runtime"**.
-  Enable this by removing the `<!--` and `-->` around the `<script defer="defer" src="./config.js"></script>` in the [`public/index.html`](../public/index.html).
-  Then run the build procedure and after completion, you can fill the `dist/config.js` with any options that you want to customize.
+  Enable this by removing the `<!--` and `-->` around the `<script defer="defer" src="./runtime-config.js"></script>` in the [`index.html`](../index.html).
+  Then run the build procedure and after completion, you can fill the `dist/runtime-config.js` with any options that you want to customize.
 
 > [!CAUTION]  
 > Appending configuration options as CLI parameters to the CLI command (e.g. `npm run build -- --catalogUrl="https://example.com"`) has been removed in  STAC Browser v5.


### PR DESCRIPTION
- Update paths: public/index.html → index.html
- Update runtime config: config.js → runtime-config.js  
- Update documentation to reflect v5 changes

Fixes Docker build errors caused by Vue 3 migration file restructuring.