### PR TITLE
Clearing SB_CONFIG in Playwright dev server configuration

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -70,12 +70,20 @@ export default defineConfig({
     ? {
         // In CI: Build and serve the production build
         command: 'npm run build && npx vite preview --port 4173 --strictPort',
+        env: {
+          ...process.env,
+          SB_CONFIG: '',
+        },
         url: 'http://localhost:4173',
         reuseExistingServer: false,
         timeout: 120 * 1000,
       }
     : {
         command: 'npm start',
+        env: {
+          ...process.env,
+          SB_CONFIG: '',
+        },
         url: 'http://localhost:8080',
         reuseExistingServer: true,
         timeout: 120 * 1000,

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,5 +1,15 @@
 import { defineConfig, devices } from '@playwright/test';
 
+function getEnvWithoutSB() {
+  const env = {};
+  for (const key in process.env) {
+    if (!key.startsWith('SB_')) {
+      env[key] = process.env[key];
+    }
+  }
+  return env;
+}
+
 /**
  * @see https://playwright.dev/docs/test-configuration
  */
@@ -70,20 +80,13 @@ export default defineConfig({
     ? {
         // In CI: Build and serve the production build
         command: 'npm run build && npx vite preview --port 4173 --strictPort',
-        env: {
-          ...process.env,
-          SB_CONFIG: '',
-        },
+        env: getEnvWithoutSB(),
         url: 'http://localhost:4173',
         reuseExistingServer: false,
         timeout: 120 * 1000,
       }
     : {
         command: 'npm start',
-        env: {
-          ...process.env,
-          SB_CONFIG: '',
-        },
         url: 'http://localhost:8080',
         reuseExistingServer: true,
         timeout: 120 * 1000,


### PR DESCRIPTION
## Proposed Changes

Follow up to #846.

Explicitly clearing `SB_CONFIG` variable when running local dev server for Playwright test suite. Without it, the overrides are picked up from local configuration overrides and expectations might not hold true, for example when authentication or custom catalogs are configured.

## Checklist

- [ ] Added [changelog entry](CHANGELOG.md)
- [ ] Added translations for new or changed UI strings
- [x] Executed linter (`npm run lint`)
- [x] Added and executed tests (`npm test`)
