### PR TITLE
Substitute datepicker in place of text input for temporal cql between…

### DIFF
--- a/src/components/QueryableInput.vue
+++ b/src/components/QueryableInput.vue
@@ -67,7 +67,7 @@
         <template #noOptions>{{ $t('search.noOptions') }}</template>
       </multiselect>
       <VueDatePicker
-        v-else-if="queryable.isTemporal"
+        v-else-if="queryable.isTemporal && (operator.SYMBOL !== 'like' && operator.SYMBOL !== 'in')"
         class="value"
         :model-value="value.value"
         @update:model-value="updateValue"


### PR DESCRIPTION
CQL LIKE shows datepicker for temporal filter, instead of a normal text field.

Note: Used the catalog below to test the like CQL on a temporal filter, but no items are retuned and between CQL only supports numeric filters.

catalog link: https://stac.opensearch.dataspace.copernicus.eu/v1/