### PR TITLE
feat(docker): add SB_CONFIG build arg for custom config overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Plugin system for widgets
 - Support for Sortables
 - Support `SB_CONFIG` for loading a custom config module
+  - Expose `SB_CONFIG` as a Docker build argument
 - Support Vite `loadEnv` for `.env` config overrides
 - CQL2 / Queryables:
   - Allow negating CQL2 filters (globally and per filter)

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,10 @@ FROM node:lts-alpine AS build-step
 ARG DYNAMIC_CONFIG=true
 ARG historyMode="history"
 ARG pathPrefix
+ARG SB_CONFIG=""
 ENV SB_historyMode="${historyMode}"
 ENV SB_pathPrefix="${pathPrefix}"
+ENV SB_CONFIG="${SB_CONFIG}"
 
 WORKDIR /app
 COPY package*.json ./

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -31,7 +31,8 @@ STAC Browser is now available at `http://localhost:8080`
 You can pass further options to STAC Browser to customize it to your needs.
 
 The build-only options
-[`pathPrefix`](./options.md#pathprefix) and [`historyMode`](./options.md#historymode)
+[`pathPrefix`](./options.md#pathprefix), [`historyMode`](./options.md#historymode),
+and `SB_CONFIG` (for loading an [external config file](./options.md))
 can be provided as a
 [build argument](https://docs.docker.com/engine/reference/commandline/build#set-build-time-variables---build-arg)
 when building the Dockerfile.
@@ -40,6 +41,14 @@ For example:
 
 ```bash
 docker build -t stac-browser:v1 --build-arg pathPrefix="/browser/" --build-arg historyMode=hash .
+```
+
+`SB_CONFIG` lets you overlay a custom config module (e.g. for options like
+[`preprocessSTAC`](./options.md#preprocessstac) that can only be set in a config file)
+without modifying the Dockerfile:
+
+```bash
+docker build -t stac-browser:v1 --build-arg SB_CONFIG=./config.custom.mjs .
 ```
 
 All other options, except the ones that are explicitly excluded from CLI/ENV usage,


### PR DESCRIPTION
## Summary

- Add `SB_CONFIG` as a Docker build argument, following the existing pattern for `pathPrefix` and `historyMode`
- Allows users to provide a custom config file at build time without modifying the Dockerfile
- No-op when unset (empty string is falsy, so `resolveExternalConfigPath("")` falls back to `config.js`)

## Usage

```sh
docker build --build-arg SB_CONFIG=./config.custom.mjs .
```

Useful for options like `preprocessSTAC` that can only be defined in a config file (`noEnv: true`, `noCLI: true`).
