### PR TITLE
feat: restrict items serach date picker to collection's temporal extent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Only show language chooser when more than one locale is available
+- Retrict items search date picker to collection's temporal extend.
 
 ## [5.0.0-beta.1] - 2026-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Only show language chooser when more than one locale is available
-- Retrict items search date picker to collection's temporal extend.
+- Restrict Collection item search date picker to collection's temporal extent
+- Focus temporal extent filter for Collection item search on end of temporal extent
+- Disable temporal extent filter when a single date/time is provided as temporal extent in the Collection metadata
 
 ## [5.0.0-beta.1] - 2026-05-12
 

--- a/src/components/SearchFilter.vue
+++ b/src/components/SearchFilter.vue
@@ -39,7 +39,7 @@
             :input-attrs="{ clearable: true }"
             :min-date="temporalExtent?.[0]"
             :max-date="temporalExtent?.[1]"
-            :prevent-min-max-navigation="!!temporalExtent"
+            :prevent-min-max-navigation="Boolean(temporalExtent)"
             auto-apply
             range
             :multi-calendars="2"

--- a/src/components/SearchFilter.vue
+++ b/src/components/SearchFilter.vue
@@ -37,6 +37,9 @@
               timePickerInline: true 
             }"
             :input-attrs="{ clearable: true }"
+            :min-date="temporalExtentMinDate"
+            :max-date="temporalExtentMaxDate"
+            :prevent-min-max-navigation="hasTemporalExtentBounds"
             auto-apply
             range
             :multi-calendars="2"
@@ -400,6 +403,32 @@ export default defineComponent({
       set(val) {
         this.query.datetime = Array.isArray(val) ? val.map(d => Utils.dateToUTC(d)) : null;
       }
+    },
+    temporalExtentMinDate() {
+      if (this.type === 'Items' && this.stac && typeof this.stac.getTemporalExtent === 'function') {
+        const extent = this.stac.getTemporalExtent();
+        if (Array.isArray(extent) && extent[0] instanceof Date) {
+          return extent[0];
+        }
+      }
+      return undefined;
+    },
+    temporalExtentMaxDate() {
+      if (this.type === 'Items' && this.stac && typeof this.stac.getTemporalExtent === 'function') {
+        const extent = this.stac.getTemporalExtent();
+        if (Array.isArray(extent) && extent[1] instanceof Date) {
+          return extent[1];
+        }
+      }
+      return undefined;
+    },
+    hasTemporalExtentBounds() {
+      return this.temporalExtentMinDate !== undefined || this.temporalExtentMaxDate !== undefined;
+    },
+    isSingleDateExtent() {
+      return this.temporalExtentMinDate instanceof Date
+        && this.temporalExtentMaxDate instanceof Date
+        && this.temporalExtentMinDate.getTime() === this.temporalExtentMaxDate.getTime();
     }
   },
   watch: {
@@ -502,6 +531,7 @@ export default defineComponent({
       );
     }
     Promise.all(promises).finally(() => this.loaded = true);
+    this.preselectSingleDateExtent();
   },
   methods: {
     resetSearchCollection() {
@@ -687,7 +717,14 @@ export default defineComponent({
     },
     async onReset() {
       Object.assign(this, getDefaults());
+      this.preselectSingleDateExtent();
       this.$emit('input', {}, true);
+    },
+    preselectSingleDateExtent() {
+      if (this.isSingleDateExtent && !Array.isArray(this.query.datetime)) {
+        const date = this.temporalExtentMinDate;
+        this.query.datetime = [date.toISOString(), date.toISOString()];
+      }
     },
     setLimit(limit) {
       limit = Number.parseInt(limit, 10);

--- a/src/components/SearchFilter.vue
+++ b/src/components/SearchFilter.vue
@@ -37,9 +37,9 @@
               timePickerInline: true 
             }"
             :input-attrs="{ clearable: true }"
-            :min-date="temporalExtentMinDate"
-            :max-date="temporalExtentMaxDate"
-            :prevent-min-max-navigation="hasTemporalExtentBounds"
+            :min-date="temporalExtent?.[0]"
+            :max-date="temporalExtent?.[1]"
+            :prevent-min-max-navigation="!!temporalExtent"
             auto-apply
             range
             :multi-calendars="2"
@@ -404,31 +404,21 @@ export default defineComponent({
         this.query.datetime = Array.isArray(val) ? val.map(d => Utils.dateToUTC(d)) : null;
       }
     },
-    temporalExtentMinDate() {
+    temporalExtent() {
       if (this.type === 'Items' && this.stac && typeof this.stac.getTemporalExtent === 'function') {
         const extent = this.stac.getTemporalExtent();
-        if (Array.isArray(extent) && extent[0] instanceof Date) {
-          return extent[0];
+        if (Array.isArray(extent)) {
+          const [min, max] = extent;
+          if (min instanceof Date || max instanceof Date) {
+            return [min instanceof Date ? min : undefined, max instanceof Date ? max : undefined];
+          }
         }
       }
-      return undefined;
-    },
-    temporalExtentMaxDate() {
-      if (this.type === 'Items' && this.stac && typeof this.stac.getTemporalExtent === 'function') {
-        const extent = this.stac.getTemporalExtent();
-        if (Array.isArray(extent) && extent[1] instanceof Date) {
-          return extent[1];
-        }
-      }
-      return undefined;
-    },
-    hasTemporalExtentBounds() {
-      return this.temporalExtentMinDate !== undefined || this.temporalExtentMaxDate !== undefined;
+      return null;
     },
     isSingleDateExtent() {
-      return this.temporalExtentMinDate instanceof Date
-        && this.temporalExtentMaxDate instanceof Date
-        && this.temporalExtentMinDate.getTime() === this.temporalExtentMaxDate.getTime();
+      const [min, max] = this.temporalExtent || [];
+      return min instanceof Date && max instanceof Date && min.getTime() === max.getTime();
     }
   },
   watch: {
@@ -722,7 +712,7 @@ export default defineComponent({
     },
     preselectSingleDateExtent() {
       if (this.isSingleDateExtent && !Array.isArray(this.query.datetime)) {
-        const date = this.temporalExtentMinDate;
+        const date = this.temporalExtent[0];
         this.query.datetime = [date.toISOString(), date.toISOString()];
       }
     },

--- a/src/components/SearchFilter.vue
+++ b/src/components/SearchFilter.vue
@@ -21,7 +21,7 @@
           </multiselect>
         </b-form-group>
 
-        <b-form-group v-if="canFilterExtents" class="filter-datetime" :label="$t('search.temporalExtent')" :label-for="ids.datetime" :description="$t('search.dateDescription')">
+        <b-form-group v-if="canFilterExtents" class="filter-datetime" :label="$t('search.temporalExtent')" :label-for="ids.datetime" :description="isSingleDateExtent ? $t('search.disabledDueToSingleDate') : $t('search.dateDescription')">
           <VueDatePicker
             input-class="form-control mx-input"
             :id="ids.datetime" 
@@ -39,10 +39,12 @@
             :input-attrs="{ clearable: true }"
             :min-date="temporalExtent?.[0]"
             :max-date="temporalExtent?.[1]"
+            :start-date="temporalExtent?.[1]"
             :prevent-min-max-navigation="Boolean(temporalExtent)"
             auto-apply
             range
             :multi-calendars="2"
+            :disabled="isSingleDateExtent"
           />
         </b-form-group>
 
@@ -521,7 +523,6 @@ export default defineComponent({
       );
     }
     Promise.all(promises).finally(() => this.loaded = true);
-    this.preselectSingleDateExtent();
   },
   methods: {
     resetSearchCollection() {
@@ -707,14 +708,7 @@ export default defineComponent({
     },
     async onReset() {
       Object.assign(this, getDefaults());
-      this.preselectSingleDateExtent();
       this.$emit('input', this.query, true);
-    },
-    preselectSingleDateExtent() {
-      if (this.isSingleDateExtent && !Array.isArray(this.query.datetime)) {
-        const date = this.temporalExtent[0];
-        this.query.datetime = [date.toISOString(), date.toISOString()];
-      }
     },
     setLimit(limit) {
       limit = Number.parseInt(limit, 10);

--- a/src/components/SearchFilter.vue
+++ b/src/components/SearchFilter.vue
@@ -718,7 +718,7 @@ export default defineComponent({
     async onReset() {
       Object.assign(this, getDefaults());
       this.preselectSingleDateExtent();
-      this.$emit('input', {}, true);
+      this.$emit('input', this.query, true);
     },
     preselectSingleDateExtent() {
       if (this.isSingleDateExtent && !Array.isArray(this.query.datetime)) {

--- a/src/locales/de/texts.json
+++ b/src/locales/de/texts.json
@@ -275,6 +275,7 @@
     "between": "zwischen",
     "betweenOperatorDescription": "Prüft, ob ein numerischer Wert innerhalb des angegebenen Bereichs liegt. Die angegebenen Grenzen werden eingeschlossen.",
     "dateDescription": "Alle Zeiten in koordinierter Weltzeit (UTC).",
+    "disabledDueToSingleDate": "Dieser Filter ist deaktiviert, da die Sammlung einen einzelnen Zeitpunkt als zeitliche Ausdehnung hat.",
     "enterCollections": "Gebe Katalog-Identifikationsnummern ein...",
     "enterItemIds": "Gebe Element-Identifikationsnummern ein...",
     "enterSearchTerms": "Gebe Suchbegriffe ein...",

--- a/src/locales/en/texts.json
+++ b/src/locales/en/texts.json
@@ -290,6 +290,7 @@
     "between": "between",
     "betweenOperatorDescription": "Tests whether a numeric field value lies within the given range. The given range is inclusive.",
     "dateDescription": "All times in Coordinated Universal Time (UTC).",
+    "disabledDueToSingleDate": "This filter is disabled because the collection has a single date and time as temporal extent.",
     "enterCollections": "Enter one or more Collection IDs...",
     "enterItemIds": "Enter one or more Item IDs...",
     "enterSearchTerms": "Enter one or more search terms...",


### PR DESCRIPTION
## Proposed Changes
When searching items within a specific collection, restrict the date-picker's selectable date range to the collection's temporal extent, and auto-select the date when the collection has a single date.

## Checklist
- [x] Added [changelog entry](CHANGELOG.md)
- [ ] Added translations for new or changed UI strings
- [x] Executed linter (`npm run lint`)
- [x] Added and executed tests (`npm test`)

