### PR TITLE
fix: hide language chooser when only one lang is configured

### DIFF
--- a/src/StacBrowser.vue
+++ b/src/StacBrowser.vue
@@ -37,6 +37,7 @@
                 <component :is="authIcon" /><span class="button-label">{{ authLabel }}</span>
               </b-button>
               <LanguageChooser
+                v-if="supportedLocalesFromVueX.length > 1"
                 :data="data" :currentLocale="localeFromVueX" :locales="supportedLocalesFromVueX"
                 @set-locale="locale => switchLocale({locale, userSelected: true})"
               />


### PR DESCRIPTION
## Proposed Changes

Hide language chooser if there is only one supported language.