### PR TITLE
Fixed icons that were slightly too large and got cut

### DIFF
--- a/src/theme/page.scss
+++ b/src/theme/page.scss
@@ -1,5 +1,3 @@
-@use 'sass:math';
-
 html,
 body {
   height: 100%;
@@ -8,6 +6,18 @@ body {
 
 body {
   margin-top: var(--sb-header-margin);
+}
+
+img,
+svg {
+  // Use center instead of middle to keep the buttons better aligned with the text
+  vertical-align: center;
+}
+
+.btn svg {
+  // Fix an issue where in some cases icons were slightly too large and were only partially shown in buttons
+  height: round(down, 1.2em, 1px);
+  width: round(down, 1.2em, 1px);
 }
 
 .list-group-item.active a {


### PR DESCRIPTION
## Proposed Changes

- Fix an issue where in some cases icons were slightly too large and were only partially shown in buttons
- Improve alignment of icons to text in buttons

@saidy-moregeo Please check whether this works in your Browser(s) as well, as discussed yesterday.

## Checklist

- [ ] Added [changelog entry](CHANGELOG.md)
- [x] Added translations for new or changed UI strings
- [x] Executed linter (`npm run lint`)
- [x] Added and executed tests (`npm test`)
