### PR TITLE
UI: handle OL styles better

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Link color on data source list selection improved
 - Improve the background color for dark mode on the map text controls.
-- Improve the map control backgroung colors on dark mode.
+- Improve the map control background colors on dark mode.
 
 ## [5.0.0-beta.1] - 2026-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Link color on data source list selection improved
 - Improve the background color for dark mode on the map text controls.
+- Improve the map control backgroung colors on dark mode.
 
 ## [5.0.0-beta.1] - 2026-05-12
 

--- a/src/components/MapView.vue
+++ b/src/components/MapView.vue
@@ -260,7 +260,7 @@ export default {
 </script>
 
 <style lang="scss">
-@import "ol/ol.css";
+@import "../theme/map.scss";
 
 #stac-browser {
   .map-popover {

--- a/src/components/maps/MapSelect.vue
+++ b/src/components/maps/MapSelect.vue
@@ -398,7 +398,7 @@ export default {
 </script>
 
 <style lang="scss">
-@import "ol/ol.css";
+@import "../../theme/map.scss";
 </style>
 
 <style lang="scss" scoped>

--- a/src/theme/map.scss
+++ b/src/theme/map.scss
@@ -2,19 +2,21 @@
 @import './variables.scss';
 
 @mixin ol-theme-vars {
-  --ol-brand-color: var(--bs-primary);
   --ol-background-color: var(--bs-body-bg);
-  --ol-foreground-color: var(--bs-body-color);
-  --ol-subtle-foreground-color: var(--bs-body-color);
-  --ol-subtle-background-color: rgba(var(--bs-secondary-rgb), 0.25);
+  --ol-subtle-background-color: rgba(var(--bs-body-bg-rgb), 0.25);
   --ol-partial-background-color: rgba(var(--bs-body-bg-rgb), 0.75);
+  --ol-foreground-color: var(--bs-body-color);
+  --ol-subtle-foreground-color: hsl(from var(--bs-body-color) h s calc(l + var(--ol-subtle-foreground-lightness-change-percentage)));
+  --ol-brand-color: var(--bs-primary);
 }
 
 :root,
 :host {
+  --ol-subtle-foreground-lightness-change-percentage: 40;
   @include ol-theme-vars;
 
   [data-bs-theme="dark"] {
+    --ol-subtle-foreground-lightness-change-percentage: -20;
     @include ol-theme-vars;
   }
 }

--- a/src/theme/map.scss
+++ b/src/theme/map.scss
@@ -2,7 +2,6 @@
 @import './variables.scss';
 
 @mixin ol-theme-vars {
-  --ol-color: var(--bs-body-color);
   --ol-brand-color: var(--bs-primary);
   --ol-background-color: var(--bs-body-bg);
   --ol-foreground-color: var(--bs-body-color);

--- a/src/theme/map.scss
+++ b/src/theme/map.scss
@@ -1,0 +1,13 @@
+@import 'ol/ol.css';
+@import './variables.scss';
+
+:root,
+:host {
+   [data-bs-theme="dark"] {
+    --ol-background-color: var(--bs-body-bg);
+    --ol-color: var(--bs-body-color);
+    --ol-foreground-color: var(--bs-body-color);
+    --ol-subtle-foreground-color: var(--bs-body-color);
+    --ol-partial-background-color: rgba(var(--bs-body-bg-rgb), 0.8);
+   }
+}

--- a/src/theme/map.scss
+++ b/src/theme/map.scss
@@ -1,13 +1,21 @@
 @import 'ol/ol.css';
 @import './variables.scss';
 
+@mixin ol-theme-vars {
+  --ol-color: var(--bs-body-color);
+  --ol-brand-color: var(--bs-primary);
+  --ol-background-color: var(--bs-body-bg);
+  --ol-foreground-color: var(--bs-body-color);
+  --ol-subtle-foreground-color: var(--bs-body-color);
+  --ol-subtle-background-color: rgba(var(--bs-secondary-rgb), 0.25);
+  --ol-partial-background-color: rgba(var(--bs-body-bg-rgb), 0.75);
+}
+
 :root,
 :host {
-   [data-bs-theme="dark"] {
-    --ol-background-color: var(--bs-body-bg);
-    --ol-color: var(--bs-body-color);
-    --ol-foreground-color: var(--bs-body-color);
-    --ol-subtle-foreground-color: var(--bs-body-color);
-    --ol-partial-background-color: rgba(var(--bs-body-bg-rgb), 0.8);
-   }
+  @include ol-theme-vars;
+
+  [data-bs-theme="dark"] {
+    @include ol-theme-vars;
+  }
 }


### PR DESCRIPTION
## Proposed Changes

Improve map controls styles on dark mode.

## Checklist

- [x] Added [changelog entry](CHANGELOG.md)
- [ ] Added translations for new or changed UI strings
- [x] Executed linter (`npm run lint`)
- [x] Added and executed tests (`npm test`)

## Dark Mode
<img width="924" height="464" alt="Screenshot 2026-05-26 at 11 51 32" src="https://github.com/user-attachments/assets/cb7316b1-b094-4d5e-960a-6c30e81c3b70" />

## Light Mode
<img width="915" height="466" alt="Screenshot 2026-05-26 at 11 52 13" src="https://github.com/user-attachments/assets/6e9af613-5962-4854-9e6a-2504ad0f1736" />
