### PR TITLE
Add `catalogTitleAfterImage` and improve the header in general

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New locales:
   - Swedish
   - Russian
+- New config option `catalogTitleAfterImage` to set a different title in the header after a logo
 
 ### Changed
 
@@ -22,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Disable temporal extent filter when a single date/time is provided as temporal extent in the Collection metadata
 - Better default STAC title detection within not fully loaded lists where only a URL is available
 - No search / sort functionality available when a static catalog has only a subset of children loaded
+- The default value for `catalogTitle` is `null` instead of `STAC Browser`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Better default STAC title detection within not fully loaded lists where only a URL is available
 - No search / sort functionality available when a static catalog has only a subset of children loaded
 - The default value for `catalogTitle` is `null` instead of `STAC Browser`.
+- Improved how the title is handled
 
 ### Fixed
 
@@ -32,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve the map control background colors on dark mode.
 - CQL2 text representation of array operators (`a_overlaps`, `a_contains`, `a_equals`, `a_contained_by`) now uses function-call syntax as defined by the CQL2 text grammar
 - Fix loading the root route when a `catalogUrl` is set
+- Fix that in some cases the `catalogUrl` is lost
 
 ## [5.0.0-beta.1] - 2026-05-12
 

--- a/config.js
+++ b/config.js
@@ -1,6 +1,7 @@
 export default {
   catalogUrl: null,
-  catalogTitle: "STAC Browser",
+  catalogTitle: null,
+  catalogTitleAfterImage: null,
   catalogImage: null,
   allowExternalAccess: true, // Must be true if catalogUrl is not given
   allowedDomains: [],

--- a/config.schema.json
+++ b/config.schema.json
@@ -9,7 +9,14 @@
       "format": "uri"
     },
     "catalogTitle": {
-      "type": ["string"]
+      "type": ["string", "null"]
+    },
+    "catalogTitleAfterImage": {
+      "type": ["string", "null"]
+    },
+    "catalogImage": {
+      "type": ["string", "null"],
+      "format": "uri"
     },
     "allowExternalAccess": {
       "type": ["boolean"]

--- a/docs/options.md
+++ b/docs/options.md
@@ -45,6 +45,7 @@ The override order for the configuration is:
 - [Basic configuration](#basic-configuration)
   - [catalogUrl](#catalogurl)
   - [catalogTitle](#catalogtitle)
+  - [catalogTitleAfterImage](#catalogtitleafterimage)
   - [catalogImage](#catalogimage)
   - [footerLinks](#footerlinks)
   - [apiCatalogPriority](#apicatalogpriority)
@@ -110,6 +111,16 @@ If `catalogUrl` is empty or set to `null` STAC Browser switches to a mode where 
 ### catalogTitle
 
 The default title shown if no title can be read from the root STAC catalog.
+
+### catalogTitleAfterImage
+
+A title to use in the header after the `catalogImage`.
+This can be useful in the following cases:
+
+- The image already contains the name and we do not want to show it twice
+- Removing the title in favor of the image - set this value to an empty string then.
+
+Only applies when `catalogImage` is not `null`.
 
 ### catalogImage
 

--- a/src/StacBrowser.vue
+++ b/src/StacBrowser.vue
@@ -24,9 +24,9 @@
           </nav>
           <div class="title">
             <StacLink v-if="root" :data="root">
-              <HeaderTitle />
+              <HeaderTitle ref="header" />
             </StacLink>
-            <HeaderTitle v-else />
+            <HeaderTitle v-else ref="header" />
           </div>
           <nav class="actions user">
             <b-button-group>
@@ -126,7 +126,6 @@ import { API_LANGUAGE_CONFORMANCE, updateExternals } from './i18n';
 import { getBest, prepareSupported } from 'stac-js/src/locales';
 import BrowserStorage from "./browser-store";
 import Authentication from "./components/Authentication.vue";
-import { getDisplayTitle } from "./models/stac";
 import Auth from './auth';
 
 // Pass Config through from props to vuex
@@ -187,7 +186,7 @@ export default defineComponent({
       enforcedColorModeFromVueX: 'enforcedColorMode',
       colorModeFromVueX: 'colorMode'
     }),
-    ...mapGetters(['canSearch', 'collectionLink', 'description', 'fromBrowserPath', 'isExternalUrl', 'isRoot', 'parentLink', 'root','supportsConformance', 'title', 'toBrowserPath']),
+    ...mapGetters(['canSearch', 'collectionLink', 'fromBrowserPath', 'isExternalUrl', 'isRoot', 'parentLink', 'root','supportsConformance', 'title', 'toBrowserPath']),
     ...mapGetters('auth', { authMethod: 'method' }),
     ...mapGetters('auth', ['canAuthenticate', 'isLoggedIn', 'showLogin']),
     browserVersion() {
@@ -281,36 +280,6 @@ export default defineComponent({
   },
   watch: {
     ...Watchers,
-    title(title) {
-      if (this.root) {
-        const rootTitle = getDisplayTitle(this.root);
-        if (rootTitle !== title) {
-          if (title) {
-            title += ' - ';
-          }
-          title += rootTitle;
-        }
-      }
-      document.title = title;
-      document.getElementById('og-title').setAttribute("content", title);
-    },
-    description(description) {
-      const summary = Utils.summarizeMd(description, 200);
-      document.getElementById('meta-description').setAttribute("content", summary);
-      document.getElementById('og-description').setAttribute("content", summary);
-    },
-    uiLanguage: {
-      immediate: true,
-      async handler(locale) {
-        if (!locale) {
-          return;
-        }
-
-        // Update the HTML lang tag
-        document.documentElement.setAttribute("lang", locale);
-        document.getElementById('og-locale').setAttribute("content", locale);
-      }
-    },
     dataLanguage: {
       immediate: true,
       async handler(locale) {
@@ -465,7 +434,9 @@ export default defineComponent({
       this.$store.commit(resetOp);
       this.parseQuery(to);
 
-      document.getElementById('og-url').setAttribute("content", window.location.href);
+      if (this.$refs.header) {
+        this.$refs.header.updateUrl();
+      }
     });
 
     const authConfig = Auth.restoreLastMethod();

--- a/src/StacBrowser.vue
+++ b/src/StacBrowser.vue
@@ -285,7 +285,10 @@ export default defineComponent({
       if (this.root) {
         const rootTitle = getDisplayTitle(this.root);
         if (rootTitle !== title) {
-          title += ` - ${rootTitle}`;
+          if (title) {
+            title += ' - ';
+          }
+          title += rootTitle;
         }
       }
       document.title = title;

--- a/src/StacBrowser.vue
+++ b/src/StacBrowser.vue
@@ -17,20 +17,16 @@
               <b-button v-if="canSearch" variant="primary" :to="searchBrowserLink" :title="$t('search.title')" :pressed="isSearchPage">
                 <b-icon-search /><span class="button-label">{{ $t('search.title') }}</span>
               </b-button>
+              <b-button v-if="root" variant="primary" id="popover-root-btn" tabindex="0">
+                <b-icon-database /><span class="button-label">{{ serviceType }}</span>
+              </b-button>
             </b-button-group>
           </nav>
           <div class="title">
-            <img v-if="logo" :src="logo.getAbsoluteUrl()" :alt="logo.title" :title="logo.title" class="logo">
-            <span role="banner">
-              <StacLink v-if="root" :data="root" hideIcon />
-              <template v-else>{{ catalogTitle }}</template>
-            </span>
-            <b-button
-              v-if="root" size="sm" variant="outline-primary" id="popover-root-btn"
-              :title="serviceType" tag="a" tabindex="0"
-            >
-              <b-icon-caret-down-fill />
-            </b-button>
+            <StacLink v-if="root" :data="root">
+              <HeaderTitle />
+            </StacLink>
+            <HeaderTitle v-else />
           </div>
           <nav class="actions user">
             <b-button-group>
@@ -117,6 +113,7 @@ import BIconLock from '~icons/bi/lock';
 import BIconUnlock from '~icons/bi/unlock';
 
 import ErrorAlert from './components/ErrorAlert.vue';
+import HeaderTitle from './components/HeaderTitle.vue';
 import Loading from './components/Loading.vue';
 import StacLink from './components/StacLink.vue';
 
@@ -158,6 +155,7 @@ export default defineComponent({
     BIconUnlock,
     BPopover: defineAsyncComponent(() => import('bootstrap-vue-next').then(m => m.BPopover)),
     ErrorAlert,
+    HeaderTitle,
     LanguageChooser: defineAsyncComponent(() => import('./components/LanguageChooser.vue')),
     Loading,
     RootStats: defineAsyncComponent(() => import('./components/RootStats.vue')),
@@ -180,7 +178,6 @@ export default defineComponent({
   computed: {
     ...mapState(['allowSelectCatalog', 'browserReady', 'conformsTo', 'data', 'dataLanguage', 'downloads', 'globalError', 'loading', 'stateQueryParameters', 'uiLanguage', 'url']),
     ...mapState({
-      catalogImageFromVueX: 'catalogImage',
       footerLinksFromVueX: 'footerLinks',
       localeFromVueX: 'locale',
       fallbackLocaleFromVueX: 'fallbackLocale',
@@ -190,7 +187,7 @@ export default defineComponent({
       enforcedColorModeFromVueX: 'enforcedColorMode',
       colorModeFromVueX: 'colorMode'
     }),
-    ...mapGetters(['canSearch', 'collectionLink', 'description', 'fromBrowserPath', 'isExternalUrl', 'isRoot', 'parentLink', 'root', 'rootLink', 'supportsConformance', 'title', 'toBrowserPath']),
+    ...mapGetters(['canSearch', 'collectionLink', 'description', 'fromBrowserPath', 'isExternalUrl', 'isRoot', 'parentLink', 'root','supportsConformance', 'title', 'toBrowserPath']),
     ...mapGetters('auth', { authMethod: 'method' }),
     ...mapGetters('auth', ['canAuthenticate', 'isLoggedIn', 'showLogin']),
     browserVersion() {
@@ -279,15 +276,7 @@ export default defineComponent({
       }
     },
     icon() {
-      return this.getIcon(this.data);
-    },
-    logo() {
-      if (this.catalogImageFromVueX) {
-        return Utils.createLink(this.catalogImageFromVueX, 'icon', this.rootLink?.title);
-      }
-      else {
-        return this.getIcon(this.root);
-      }
+      return Utils.getIcon(this.data);
     }
   },
   watch: {
@@ -505,15 +494,6 @@ export default defineComponent({
     ...mapActions('auth', ['requestLogin', 'requestLogout']),
     toggleColorMode() {
       this.colorMode = this.colorMode === 'light' ? 'dark' : 'light';
-    },
-    getIcon(data) {
-      if (data instanceof STAC) {
-        const icons = data.getIcons();
-        if (icons.length > 0) {
-          return icons[0];
-        }
-      }
-      return null;
     },
     async logInOut() {
       if (this.url) {

--- a/src/components/HeaderTitle.vue
+++ b/src/components/HeaderTitle.vue
@@ -13,7 +13,7 @@ import { getDisplayTitle } from "../models/stac";
 export default {
   name: "HeaderTitle",
   computed: {
-    ...mapState(['catalogUrl', 'catalogImage', 'catalogTitle', 'catalogTitleAfterImage']),
+    ...mapState(['catalogUrl', 'catalogImage', 'catalogTitle', 'catalogTitleAfterImage', 'loading', 'url']),
     ...mapGetters(['root', 'rootLink']),
     logo() {
       if (this.catalogImage) {
@@ -34,8 +34,15 @@ export default {
         return getDisplayTitle(this.root);
       }
       else {
-        // To change this default title, add "STAC Browser": "Your Title" to the custom.json locale file
-        return this.$i18n.t('STAC Browser');
+        if (this.url && this.loading) {
+          // If the page is still loading, we don't show a title to not have a quick flash
+          // of the default title before the actual title is loaded.
+          return '';
+        }
+        else {
+          // To change this default title, add "STAC Browser": "Your Title" to the custom.json locale file
+          return this.$t('STAC Browser');
+        }
       }
     }
   }

--- a/src/components/HeaderTitle.vue
+++ b/src/components/HeaderTitle.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="header-title">
     <img v-if="logo" :src="logo.getAbsoluteUrl()" :alt="logo.title" :title="logo.title" class="logo">
-    <span role="banner">{{ title }}</span>
+    <span role="banner">{{ headerTitle }}</span>
   </div>
 </template>
 
@@ -13,8 +13,8 @@ import { getDisplayTitle } from "../models/stac";
 export default {
   name: "HeaderTitle",
   computed: {
-    ...mapState(['catalogUrl', 'catalogImage', 'catalogTitle', 'catalogTitleAfterImage', 'loading', 'url']),
-    ...mapGetters(['root', 'rootLink']),
+    ...mapState(['catalogUrl', 'catalogImage', 'catalogTitle', 'catalogTitleAfterImage', 'description', 'loading', 'url', 'uiLanguage']),
+    ...mapGetters(['description', 'root', 'rootLink', 'title']),
     logo() {
       if (this.catalogImage) {
         return Utils.createLink(this.catalogImage, 'icon', this.catalogTitle || this.rootLink?.title);
@@ -23,8 +23,11 @@ export default {
         return Utils.getIcon(this.root);
       }
     },
-    title() {
-      if (this.logo && this.catalogTitleAfterImage !== null) {
+    fallbackTitle() {
+      return this.$t('STAC Browser');
+    },
+    headerTitle() {
+      if (this.catalogImage && this.catalogTitleAfterImage !== null) {
         return this.catalogTitleAfterImage;
       }
       else if (this.catalogTitle) {
@@ -41,9 +44,57 @@ export default {
         }
         else {
           // To change this default title, add "STAC Browser": "Your Title" to the custom.json locale file
-          return this.$t('STAC Browser');
+          return this.fallbackTitle;
         }
       }
+    },
+    documentTitle() {
+      const titles = new Set();
+      if (this.title) {
+        titles.add(this.title);
+      }
+      if (this.headerTitle) {
+        titles.add(this.headerTitle);
+      }
+      return Array.from(titles).join(' - ');
+    }
+  },
+  watch: {
+    documentTitle: {
+      immediate: true,
+      handler(documentTitle) {
+        const title = documentTitle || this.fallbackTitle;
+        document.title = title;
+        document.getElementById('og-title').setAttribute("content", title);
+      }
+    },
+    description: {
+      immediate: true,
+      handler(description) {
+        if (!description) {
+          return;
+        }
+        const summary = Utils.summarizeMd(description, 200);
+        document.getElementById('meta-description').setAttribute("content", summary);
+        document.getElementById('og-description').setAttribute("content", summary);
+      }
+    },
+    uiLanguage: {
+      immediate: true,
+      async handler(locale) {
+        if (!locale) {
+          return;
+        }
+
+        // Update the HTML lang tag
+        document.documentElement.setAttribute("lang", locale);
+        document.getElementById('og-locale').setAttribute("content", locale);
+      }
+    },
+  },
+  methods: {
+    updateUrl() {
+      document.getElementById('og-url').setAttribute("content", window.location.href);
     }
   }
 };

--- a/src/components/HeaderTitle.vue
+++ b/src/components/HeaderTitle.vue
@@ -1,0 +1,43 @@
+<template>
+  <div class="header-title">
+    <img v-if="logo" :src="logo.getAbsoluteUrl()" :alt="logo.title" :title="logo.title" class="logo">
+    <span role="banner">{{ title }}</span>
+  </div>
+</template>
+
+<script>
+import { mapState, mapGetters } from "vuex";
+import Utils from "../utils";
+import { getDisplayTitle } from "../models/stac";
+
+export default {
+  name: "HeaderTitle",
+  computed: {
+    ...mapState(['catalogUrl', 'catalogImage', 'catalogTitle', 'catalogTitleAfterImage']),
+    ...mapGetters(['root', 'rootLink']),
+    logo() {
+      if (this.catalogImage) {
+        return Utils.createLink(this.catalogImage, 'icon', this.catalogTitle || this.rootLink?.title);
+      }
+      else {
+        return Utils.getIcon(this.root);
+      }
+    },
+    title() {
+      if (this.logo && this.catalogTitleAfterImage !== null) {
+        return this.catalogTitleAfterImage;
+      }
+      else if (this.catalogTitle) {
+        return this.catalogTitle;
+      }
+      else if (this.root) {
+        return getDisplayTitle(this.root);
+      }
+      else {
+        // To change this default title, add "STAC Browser": "Your Title" to the custom.json locale file
+        return this.$i18n.t('STAC Browser');
+      }
+    }
+  }
+};
+</script>

--- a/src/components/StacLink.vue
+++ b/src/components/StacLink.vue
@@ -1,7 +1,9 @@
 <template>
   <component :is="component" class="stac-link" :id="id" :title="tooltip" v-bind="attributes">
-    <img v-if="icon && !hideIcon" :src="icon.getAbsoluteUrl()" :alt="icon.title" :title="icon.title" class="icon me-2">
-    <span class="title">{{ displayTitle }}</span>
+    <slot>
+      <img v-if="icon && !hideIcon" :src="icon.getAbsoluteUrl()" :alt="icon.title" :title="icon.title" class="icon me-2">
+      <span class="title">{{ displayTitle }}</span>
+    </slot>
   </component>
 </template>
 
@@ -163,7 +165,6 @@ export default defineComponent({
       else {
         return this.getRequestUrl(this.link.href);
       }
-
     },
     displayTitle() {
       if (this.title) {

--- a/src/rels.js
+++ b/src/rels.js
@@ -20,6 +20,9 @@ export const stacBrowserSpecialHandling = [
   'data',
   'items',
   'search',
+  'aggregate', // (Irrelevant) Extensions v
+  'aggregations',
+  'collections-search',
   'icon', // Other v
   'license',
 ].concat(hierarchical).concat(pagination).concat(queryables);

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -853,7 +853,7 @@ function getStore(config, router) {
           // If we don't have a catalogUrl but have a page to show,
           // we should assume this URL is the root catalog for now.
           if (!cx.state.catalogUrl) {
-            cx.commit('config', { catalogUrl: url });
+            await cx.dispatch('config', { catalogUrl: url });
           }
         }
       },

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -850,6 +850,11 @@ function getStore(config, router) {
         // All tasks finished, show the page if requested
         if (loading.show) {
           cx.commit('showPage', { url });
+          // If we don't have a catalogUrl but have a page to show,
+          // we should assume this URL is the root catalog for now.
+          if (!cx.state.catalogUrl) {
+            cx.commit('config', { catalogUrl: url });
+          }
         }
       },
       async loadApiItems(cx, args) {

--- a/src/theme/page.scss
+++ b/src/theme/page.scss
@@ -28,10 +28,6 @@ svg {
   }
 }
 
-#popover-root-btn {
-  border: 0;
-}
-
 #stac-browser {
   display: flex;
   flex-direction: column;
@@ -47,17 +43,37 @@ svg {
   > header {
     .site {
       border-bottom: var(--sb-header-border);
+      
+      @include media-breakpoint-up(lg) {
+        .actions {
+          min-width: 300px;
+        }
+      }
+
+      .user {
+        text-align: right;
+      }
 
       > .col-md-12 {
         > .title {
-          > span {
-            font-size: var(--sb-header-font-size);
-            font-weight: var(--sb-header-font-weight);
-          }
-        }
+          display: flex;
+          align-items: center;
+          gap: var(--sb-header-font-size);
+          
+          .header-title {
+            display: flex;
+            align-items: center;
+            gap: var(--sb-header-font-size);
 
-        .logo {
-          max-height: var(--sb-logo-max-height);
+            .logo {
+              max-height: var(--sb-logo-max-height);
+            }
+
+            span[role="banner"] {
+              font-size: var(--sb-header-font-size);
+              font-weight: var(--sb-header-font-weight);
+            }
+          }
         }
       }
     }
@@ -309,7 +325,8 @@ svg {
   @include media-breakpoint-up(lg) {
     .button-label {
       display: inline-block;
-      margin-left: 0.25rem;
+      margin-left: 0.33rem;
+      margin-right: 0.1rem;
       white-space: nowrap;
     }
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,6 @@
 import { URI } from 'stac-js/src/utils.js';
 import removeMd from 'remove-markdown';
-import { Link, Asset } from 'stac-js';
+import { Link } from 'stac-js';
 import { hasText, isObject, size } from 'stac-js/src/utils.js';
 import { geojsonMediaType, imageMediaTypes } from 'stac-js/src/mediatypes.js';
 import { pagination } from "stac-js/src/relationtypes.js";
@@ -262,6 +262,16 @@ export default class Utils {
     }
   }
 
+  static getIcon(data) {
+    if (data?.isSTAC) {
+      const icons = data.getIcons();
+      if (icons.length > 0) {
+        return icons[0];
+      }
+    }
+    return null;
+  }
+
   static titleForHref(href, preferFileName = false) {
     const uri = URI(href);
     const auth = uri.authority();
@@ -369,7 +379,7 @@ export default class Utils {
 
   static assetFilename(asset, response = null) {
     // Get the preferred filename from the file:local_path property
-    if (asset instanceof Asset) {
+    if (asset.isAsset) {
       const localPath = asset.getMetadata('file:local_path');
       if (typeof localPath === 'string') {
         return URI(localPath).filename();

--- a/src/utils.js
+++ b/src/utils.js
@@ -379,7 +379,7 @@ export default class Utils {
 
   static assetFilename(asset, response = null) {
     // Get the preferred filename from the file:local_path property
-    if (asset.isAsset) {
+    if (asset?.isAsset) {
       const localPath = asset.getMetadata('file:local_path');
       if (typeof localPath === 'string') {
         return URI(localPath).filename();

--- a/tests/e2e/homepage.spec.js
+++ b/tests/e2e/homepage.spec.js
@@ -16,18 +16,18 @@ const catalogs = JSON.parse(fs.readFileSync(path.resolve(
 )));
 import CONFIG from '../../config.js';
 
-test.describe('STAC Browser Homepage', () => {
+test.describe('STAC Browser Data Source Selection', () => {
   // ensure every test uses the mocked STAC Index response
   test.beforeEach(async ({ worker }) => {
     await mockStacResource(worker, 'https://stacindex.org/api/catalogs', catalogs);
   });
-  test('should load the homepage successfully', async ({ page }) => {
-    // Navigate to the homepage (STAC Index already mocked in beforeEach)
+  test('should load the data source selection successfully', async ({ page }) => {
+    // Navigate to the data source selection (STAC Index already mocked in beforeEach)
     await page.goto(HOME_PATH);
     
     // Check if the page title is visible
     await expect(page.locator('header [role="banner"]')).toBeVisible();
-    
+
     // Verify the page loads without errors
     await expect(page).toHaveTitle(/STAC Browser/);
     


### PR DESCRIPTION
## Proposed Changes

- New config option `catalogTitleAfterImage` to set a different title in the header after a logo
- The default value for `catalogTitle` is `null` instead of `STAC Browser`.
- Improved how the title is handled; make logo clickable
- Fix that in some cases the `catalogUrl` is lost

## Checklist

- [x] Added [changelog entry](CHANGELOG.md)
- [x] Added translations for new or changed UI strings
- [x] Executed linter (`npm run lint`)
- [ ] Added and executed tests (`npm test`)
