### PR TITLE
Allow to configure default alternate asset #500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New locales:
   - Swedish
   - Russian
-- New config option `catalogTitleAfterImage` to set a different title in the header after a logo
+- New config options:
+  - `catalogTitleAfterImage`: Set a different title in the header after a logo.
+  - `defaultCollectionSort`: Default sort order for Collections (replaces `cardViewSort`). The new default is different from the old default behaviour.
+  - `defaultItemSort`: Default sort order for Items (replaces `cardViewSort`). The new default is different from the old default behaviour.
+  - `preferredAssets`: Configure which (alternate) asset is shown by default. Defaults to preferring HTTP(S) alternates; set to `false` to revert back to the previous behaviour.
 
 ### Changed
 
-- Replaced `cardViewSort` with new options `defaultCollectionSort` and `defaultItemSort`
 - Only show language chooser when more than one locale is available
 - Restrict Collection item search date picker to collection's temporal extent
 - Focus temporal extent filter for Collection item search on end of temporal extent
@@ -26,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - No search / sort functionality available when a static catalog has only a subset of children loaded
 - The default value for `catalogTitle` is `null` instead of `STAC Browser`.
 - Improved how the title is handled
+
+### Removed
+
+- Removed `cardViewSort` config option in favor of `defaultCollectionSort` and `defaultItemSort`
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ You need to provide a field `stac_browser` and then you can set any of the follo
 - `defaultItemSort`
 - `defaultThumbnailSize`
 - `displayGeoTiffByDefault`
+- `preferredAssets`
 - `showThumbnailsAsAssets`
 
 Additionally, you can add an `extent` object **outside** of the `stac_browser` field to

--- a/config.js
+++ b/config.js
@@ -47,6 +47,7 @@ export default {
   defaultItemSort: null,
   showKeywordsInItemCards: false,
   showKeywordsInCatalogCards: false,
+  preferredAssets: true,
   showThumbnailsAsAssets: false,
   searchResultsPerPage: null,
   itemsPerPage: null,

--- a/config.schema.json
+++ b/config.schema.json
@@ -142,6 +142,10 @@
         "type": ["string"]
       }
     },
+    "preferredAssets": {
+      "type": ["boolean", "string"],
+      "description": "Preferred asset selection strategy: false (show main asset), true (prefer HTTP/S), or asset key name (string)"
+    },
     "preprocessSTAC": {
       "type": ["null"],
       "format": "function",

--- a/docs/options.md
+++ b/docs/options.md
@@ -79,17 +79,20 @@ The override order for the configuration is:
   - [getMapSourceOptions](#getmapsourceoptions)
 - [User Interface](#user-interface)
   - [enforcedColorMode](#enforcedcolormode)
+  - [cardViewMode](#cardviewmode)
+  - [showKeywordsInItemCards](#showkeywordsinitemcards)
+  - [showKeywordsInCatalogCards](#showkeywordsincatalogcards)
+  - [defaultThumbnailSize](#defaultthumbnailsize)
+- [Metadata Retrieval](#metadata-retrieval)
   - [searchResultsPerPage](#searchresultsperpage)
   - [itemsPerPage](#itemsperpage)
   - [collectionsPerPage](#collectionsperpage)
   - [maxEntriesPerPage](#maxentriesperpage)
-  - [cardViewMode](#cardviewmode)
   - [defaultCollectionSort](#defaultcollectionsort)
   - [defaultItemSort](#defaultitemsort)
-  - [showKeywordsInItemCards](#showkeywordsinitemcards)
-  - [showKeywordsInCatalogCards](#showkeywordsincatalogcards)
+- [Assets](#assets)
+  - [preferredAssets](#preferredassets)
   - [showThumbnailsAsAssets](#showthumbnailsasassets)
-  - [defaultThumbnailSize](#defaultthumbnailsize)
 - [Service Integration](#service-integration)
   - [socialSharing](#socialsharing)
 - [Advanced](#advanced)
@@ -485,6 +488,25 @@ STAC Browser supports light and dark modes since v5.0.0.
 By default, this value is set to `auto`, which detects the user preference based on the system settings.
 This config option allows to enforce a specific color mode, either `light` (default before v5.0.0) or `dark`.
 
+### cardViewMode
+
+The default view mode for lists of catalogs/collections. Either `"list"` or `"cards"` (default).
+
+### showKeywordsInItemCards
+
+Enables keywords in the lists of items if set to `true`. Defaults to `false`.
+
+### showKeywordsInCatalogCards
+
+Enables keywords in the lists of catalogs/collections if set to `true`. Defaults to `false`.
+
+### defaultThumbnailSize
+
+The default size \[Height, Width\] for thumbnails which is reserved in card and list views so that the items don't jump when loading the images.
+This can be overridden per thumbnail by declaring the [`proj:shape`](https://github.com/stac-extensions/projection/#item-properties-or-asset-fields) on the asset or link.
+
+## Metadata Retrieval
+
 ### searchResultsPerPage
 
 The number of items requested and shown per page by default for search results, i.e. global item search and collection search.
@@ -516,10 +538,6 @@ This applies to the following requests:
 ### maxEntriesPerPage
 
 The maximum number of items per page that a user can request through the `limit` query parameter (`1000` by default).
-
-### cardViewMode
-
-The default view mode for lists of catalogs/collections. Either `"list"` or `"cards"` (default).
 
 ### defaultCollectionSort
 
@@ -555,22 +573,23 @@ Alternatively, you can use `null` to keep it sorted as in the source (default).
 
 Doesn't apply when the catalog is static and not all information is loaded yet.
 
-### showKeywordsInItemCards
+## Assets
 
-Enables keywords in the lists of items if set to `true`. Defaults to `false`.
+### preferredAssets
 
-### showKeywordsInCatalogCards
+Allows you to configure how asset alternatives should be displayed by default when a STAC Asset within an Item or Collection has multiple alternatives.
 
-Enables keywords in the lists of catalogs/collections if set to `true`. Defaults to `false`.
+The following options are supported:
+
+- `false`: The main asset is shown first, alternates are displayed as additional tabs.
+- `true` (default): HTTP(S) assets are preferred. If the main asset uses HTTP(S), it's selected by default. Otherwise, the first HTTP(S) alternative is selected.
+- `"assetKeyName"` (string): Specifies the key of the preferred asset to display by default. For example, `"s3"` would pre-select the asset with key `s3` if it exists as an alternative.
+
+This is useful when you want to automatically display a specific asset variant (e.g., the HTTPS version accessible directly through the browser) instead of the main asset.
 
 ### showThumbnailsAsAssets
 
 Defines whether thumbnails are shown in the lists of assets (`true`) or not (`false`, default).
-
-### defaultThumbnailSize
-
-The default size \[Height, Width\] for thumbnails which is reserved in card and list views so that the items don't jump when loading the images.
-This can be overridden per thumbnail by declaring the [`proj:shape`](https://github.com/stac-extensions/projection/#item-properties-or-asset-fields) on the asset or link.
 
 ## Service Integration
 
@@ -584,7 +603,6 @@ The following services are supported:
 - `bsky` (Bluesky)
 - `mastodon` (Mastodon.social)
 - `x` (X, formerly Twitter)
-
 ## Advanced
 
 ### preprocessSTAC

--- a/src/StacBrowser.vue
+++ b/src/StacBrowser.vue
@@ -351,11 +351,12 @@ export default defineComponent({
       const canChange = [
         'apiCatalogPriority',
         'cardViewMode',
+        'crossOriginMedia',
         'defaultCollectionSort',
         'defaultItemSort',
-        'crossOriginMedia',
         'defaultThumbnailSize',
         'displayGeoTiffByDefault',
+        'preferredAssets',
         'showThumbnailsAsAssets'
       ];
 

--- a/src/components/Asset.vue
+++ b/src/components/Asset.vue
@@ -28,11 +28,11 @@
    
     <template v-if="hasAlternatives">
       <b-card no-body class="border-0 rounded-0">
-        <b-tabs lazy card>
-          <b-tab :title="asset['alternate:name'] || $t('assets.alternate.main')" active no-body>
+        <b-tabs v-model="activeTab" lazy card>
+          <b-tab :id="mainTabId" :title="asset['alternate:name'] || $t('assets.alternate.main')" no-body>
             <AssetAlternative :asset="asset" :shown="shown" hasAlternatives @show="show" />
           </b-tab>
-          <b-tab v-for="(altAsset, key) in alternatives" :title="altAsset['alternate:name'] || key" :key="key" no-body>
+          <b-tab v-for="(altAsset, key) in alternatives" :id="getAlternativeTabId(key)" :title="altAsset['alternate:name'] || key" :key="key" no-body>
             <AssetAlternative :asset="altAsset" :shown="shown" hasAlternatives @show="show" />
           </b-tab>
         </b-tabs>
@@ -83,11 +83,12 @@ export default {
   emits: ['show'],
   data() {
     return {
-      expanded: false
+      expanded: false,
+      activeTab: null
     };
   },
   computed: {
-    ...mapState(['stateQueryParameters']),
+    ...mapState(['stateQueryParameters', 'preferredAssets']),
     type() {
       return this.definition ? 'itemdef' : 'asset';
     },
@@ -96,6 +97,9 @@ export default {
     },
     title() {
       return this.asset.title || this.asset.getKey();
+    },
+    mainTabId() {
+      return `${this.uid}-main`;
     },
     fileFormat() {
       if (typeof this.asset.type === "string" && this.asset.type.length > 0) {
@@ -138,6 +142,52 @@ export default {
         }
         return a.toLowerCase().localeCompare(b.toLowerCase(), undefined, { sensitivity: 'base' });
       });
+    },
+    preferredTabId() {
+      if (!this.hasAlternatives) {
+        return this.mainTabId;
+      }
+
+      if (!this.preferredAssets) {
+        return this.mainTabId;
+      }
+
+      // If preferredAssets is a string, it's the key of the preferred asset
+      if (typeof this.preferredAssets === 'string') {
+        if (this.preferredAssets === this.asset.getKey()) {
+          return this.mainTabId;
+        }
+        if (Object.prototype.hasOwnProperty.call(this.alternatives, this.preferredAssets)) {
+          return this.getAlternativeTabId(this.preferredAssets);
+        }
+      }
+
+      // If preferredAssets is true, prefer HTTP(S) assets
+      if (this.preferredAssets === true) {
+        // Main asset has priority over alternatives
+        if (this.asset.isHTTP) {
+          return this.mainTabId;
+        }
+        
+        // Find first HTTP(S) alternative
+        const alternativeKeys = Object.keys(this.alternatives);
+        for (let i = 0; i < alternativeKeys.length; i++) {
+          const key = alternativeKeys[i];
+          if (this.alternatives[key].isHTTP) {
+            return this.getAlternativeTabId(key);
+          }
+        }
+      }
+
+      return this.mainTabId;
+    }
+  },
+  watch: {
+    preferredTabId: {
+      immediate: true,
+      handler(tabId) {
+        this.activeTab = tabId;
+      }
     }
   },
   created() {
@@ -154,6 +204,9 @@ export default {
     }
   },
   methods: {
+    getAlternativeTabId(key) {
+      return `${this.uid}-alt-${String(key).toLowerCase().replace(/[^\w]/g, '-')}`;
+    },
     displayRole(role) {
       let key = `assets.role.${role}`;
       if (this.$te(key)) {


### PR DESCRIPTION
## Proposed Changes

Closes #500

Configure preferred asset alternate to show. Defaults to HTTPS.

## Checklist

- [x] Added [changelog entry](CHANGELOG.md)
- [x] Added translations for new or changed UI strings
- [x] Executed linter (`npm run lint`)
- [x] Added and executed tests (`npm test`)
