### PR TITLE
Refactor internal stac-js, auth retries, state handling for API children, and Browse menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix global error handling in certain edge-cases
 - Improve speed of catalog/collection duplicate detection
 - Fix search link detection
+- The configured default collection and item sort is also applied to the Browse menu
 
 ## [5.0.0-rc.1] - 2026-06-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `getBrowserPath` for STAC Objects is not available any longer, use `toBrowserPath` or other URL comparison mechanisms instead.
   **Note:** This is commonly used in `preprocessSTAC` config option, ensure to update your `config.js`.
+- Internal rewrite of how API children are maintained
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `getBrowserPath` for STAC Objects is not available any longer, use `toBrowserPath` or other URL comparison mechanisms instead.
+  **Note:** This is commonly used in `preprocessSTAC` config option, ensure to update your `config.js`.
+
 ### Fixed
 
 - Fix global error handling in certain edge-cases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The Browse menu also loads additional Collections on demand
+
 ### Changed
 
 - `getBrowserPath` for STAC Objects is not available any longer, use `toBrowserPath` or other URL comparison mechanisms instead.
   **Note:** This is commonly used in `preprocessSTAC` config option, ensure to update your `config.js`.
 - Internal rewrite of how API children are maintained
+- Loaded collections are cached and no longer re-fetched when returning to a page
 
 ### Fixed
 
@@ -19,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve speed of catalog/collection duplicate detection
 - Fix search link detection
 - The configured default collection and item sort is also applied to the Browse menu
+- More requests that fail due to missing authentication are retried after login (incl. searches and downloads)
+- A failed background load no longer switches the page after login
 
 ## [5.0.0-rc.1] - 2026-06-27
 

--- a/basemaps.config.js
+++ b/basemaps.config.js
@@ -1,5 +1,4 @@
-import { Collection } from './src/models/stac';
-import { STAC } from 'stac-js';
+import { Collection, STAC } from 'stac-js';
 
 // For documentation see https://github.com/radiantearth/stac-browser/blob/main/docs/basemaps.md
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -643,7 +643,7 @@ Of course, ideally you'd want to update the root catalog itself, but until then 
 
 ```js
 preprocessSTAC: (stac, state) => {
-    if (stac.getBrowserPath() === '/') {
+    if (stac.getAbsoluteUrl() === state.catalogUrl) {
         stac.title = state.catalogTitle;
         stac.description = 'This is a **much** more useful description for this catalog!';
     }

--- a/docs/options.md
+++ b/docs/options.md
@@ -642,8 +642,8 @@ Thus, it may make sense to change the root catalog to provide more useful inform
 Of course, ideally you'd want to update the root catalog itself, but until then you can use this.
 
 ```js
-preprocessSTAC: (stac, state) => {
-    if (stac.getAbsoluteUrl() === state.catalogUrl) {
+preprocessSTAC: (stac, state, getters) => {
+    if (getters.toBrowserPath(stac.getAbsoluteUrl()) === '/') {
         stac.title = state.catalogTitle;
         stac.description = 'This is a **much** more useful description for this catalog!';
     }

--- a/src/StacBrowser.vue
+++ b/src/StacBrowser.vue
@@ -61,10 +61,10 @@
               <b-button v-if="back" :to="selfBrowserLink" :title="$t('goBack.description', {type})" variant="outline-primary" size="sm">
                 <b-icon-arrow-left /><span class="button-label">{{ $t('goBack.label') }}</span>
               </b-button>
-              <b-button v-if="collectionLink" :to="toBrowserPath(collectionLink.href)" :title="collectionLinkTitle" variant="outline-primary" size="sm">
+              <b-button v-if="collectionLink" :to="toBrowserPath(collectionLink)" :title="collectionLinkTitle" variant="outline-primary" size="sm">
                 <b-icon-folder-symlink /><span class="button-label">{{ $t('goToCollection.label') }}</span>
               </b-button>
-              <b-button v-if="parentLink" :to="toBrowserPath(parentLink.href)" :title="parentLinkTitle" variant="outline-primary" size="sm">
+              <b-button v-if="parentLink" :to="toBrowserPath(parentLink)" :title="parentLinkTitle" variant="outline-primary" size="sm">
                 <b-icon-arrow-90deg-up /><span class="button-label">{{ $t('goToParent.label') }}</span>
               </b-button>
             </b-button-group>
@@ -275,7 +275,7 @@ export default defineComponent({
             const state = Object.assign({}, this.stateQueryParameters);
             this.isNavigatingLocale = true;
             try {
-              await this.$router.push(this.toBrowserPath(link.href));
+              await this.$router.push(this.toBrowserPath(link));
             }
             catch (error) {
               if (!isNavigationFailure(error, NavigationFailureType.duplicated)) {

--- a/src/StacBrowser.vue
+++ b/src/StacBrowser.vue
@@ -449,8 +449,7 @@ export default defineComponent({
         this.addAction(() => this.$store.dispatch('load', {
           url: this.url,
           show: true,
-          force: true,
-          noRetry: true
+          force: true
         }));
       }
       if (this.isLoggedIn) {

--- a/src/components/SearchFilter.vue
+++ b/src/components/SearchFilter.vue
@@ -177,7 +177,7 @@ import DatePickerMixin from './DatePickerMixin';
 import Loading from './Loading.vue';
 
 import { CollectionCollection, STAC } from 'stac-js'; 
-import { createSTAC, getApiChildrenState, getChildren, setApiDataListener } from '../models/stac';
+import { createSTAC } from '../models/stac';
 import Cql from '../models/cql2/cql';
 import Queryable from '../models/cql2/queryable';
 import CqlLogicalOperator, { CqlNot } from '../models/cql2/operators/logical';
@@ -274,7 +274,7 @@ export default defineComponent({
   },
   computed: {
     ...mapState(['defaultCollectionSort', 'defaultItemSort', 'searchResultsPerPage', 'maxEntriesPerPage', 'uiLanguage']),
-    ...mapGetters(['canSearchCollections', 'supportsConformance']),
+    ...mapGetters(['canSearchCollections', 'getApiChildrenState', 'supportsConformance']),
     collectionSelectOptions() {
       let taggable = !this.hasAllCollections;
       let isResult = this.collections.length > 0 && !this.hasAllCollections;
@@ -421,20 +421,36 @@ export default defineComponent({
     isSingleDateExtent() {
       const [min, max] = this.temporalExtent || [];
       return min instanceof Date && max instanceof Date && min.getTime() === max.getTime();
+    },
+    apiCollectionsState() {
+      if (!this.parent?.isCatalogLike) {
+        return null;
+      }
+      return this.getApiChildrenState(this.parent);
+    },
+    apiCollectionsFromStore() {
+      const list = this.apiCollectionsState?.list;
+      if (!Array.isArray(list)) {
+        return [];
+      }
+      return list.filter(collection => collection instanceof STAC && collection.isCollection);
+    },
+    apiCollectionsPaginated() {
+      return Boolean(this.apiCollectionsState?.next || this.apiCollectionsState?.prev);
     }
   },
   watch: {
     parent: {
       immediate: true,
-      handler(newStac, oldStac) {
-        if (newStac?.isCatalogLike) {
-          setApiDataListener(newStac, 'searchfilter' + formId, () => this.updateApiCollections());
-        }
-        if (oldStac?.isCatalogLike) {
-          setApiDataListener(oldStac, 'searchfilter' + formId);
-        }
+      handler() {
         this.updateApiCollections();
       }
+    },
+    apiCollectionsFromStore() {
+      this.updateApiCollections();
+    },
+    apiCollectionsPaginated() {
+      this.updateApiCollections();
     },
     value: {
       immediate: true,
@@ -600,9 +616,8 @@ export default defineComponent({
       if (!this.parent) {
         return;
       }
-      let apiCollections = getChildren(this.parent, 'collections');
-      let nextCollectionsLink = getApiChildrenState(this.parent)?.next;
-      if (!Array.isArray(apiCollections) || nextCollectionsLink || !this.conformances.CollectionIdFilter) {
+      let apiCollections = this.apiCollectionsFromStore;
+      if (!Array.isArray(apiCollections) || this.apiCollectionsPaginated || !this.conformances.CollectionIdFilter) {
         this.collections = [];
         return;
       }

--- a/src/components/SearchFilter.vue
+++ b/src/components/SearchFilter.vue
@@ -566,7 +566,7 @@ export default defineComponent({
           // Only set collections if response is valid AND collectionsLoadingTimer has not been reset.
           // If collectionsLoadingTimer has been reset, the result is not relevant anylonger.
           if (this.collectionsLoadingTimer && CollectionCollection.isResponse(response.data)) {
-            const stac = createSTAC(response.data);
+            const stac = createSTAC(response.data, null, this.$store);
             this.collections = this.prepareCollections(stac.getAll());
             if (typeof stac.numberMatched === 'number') {
               this.additionalCollectionCount = stac.numberMatched - this.collections.length;
@@ -597,7 +597,7 @@ export default defineComponent({
           return {};
         }
 
-        const stac = createSTAC(response.data);
+        const stac = createSTAC(response.data, null, this.$store);
         if (typeof stac.getQueryablesLink === 'function') {
           data.queryableLink = stac.getQueryablesLink();
         }

--- a/src/components/SearchFilter.vue
+++ b/src/components/SearchFilter.vue
@@ -177,7 +177,7 @@ import DatePickerMixin from './DatePickerMixin';
 import Loading from './Loading.vue';
 
 import { CollectionCollection, STAC } from 'stac-js'; 
-import { createSTAC, Collection } from '../models/stac';
+import { createSTAC, getApiChildrenState, getChildren, setApiDataListener } from '../models/stac';
 import Cql from '../models/cql2/cql';
 import Queryable from '../models/cql2/queryable';
 import CqlLogicalOperator, { CqlNot } from '../models/cql2/operators/logical';
@@ -427,11 +427,11 @@ export default defineComponent({
     parent: {
       immediate: true,
       handler(newStac, oldStac) {
-        if (newStac instanceof Collection) {
-          newStac.setApiDataListener('searchfilter' + formId, () => this.updateApiCollections());
+        if (newStac?.isCatalogLike) {
+          setApiDataListener(newStac, 'searchfilter' + formId, () => this.updateApiCollections());
         }
-        if (oldStac instanceof Collection) {
-          oldStac.setApiDataListener('searchfilter' + formId);
+        if (oldStac?.isCatalogLike) {
+          setApiDataListener(oldStac, 'searchfilter' + formId);
         }
         this.updateApiCollections();
       }
@@ -600,8 +600,8 @@ export default defineComponent({
       if (!this.parent) {
         return;
       }
-      let apiCollections = this.parent.getChildren('collections');
-      let nextCollectionsLink = this.parent._apiChildren.next;
+      let apiCollections = getChildren(this.parent, 'collections');
+      let nextCollectionsLink = getApiChildrenState(this.parent)?.next;
       if (!Array.isArray(apiCollections) || nextCollectionsLink || !this.conformances.CollectionIdFilter) {
         this.collections = [];
         return;

--- a/src/components/SearchFilter.vue
+++ b/src/components/SearchFilter.vue
@@ -181,7 +181,6 @@ import { createSTAC } from '../models/stac';
 import Cql from '../models/cql2/cql';
 import Queryable from '../models/cql2/queryable';
 import CqlLogicalOperator, { CqlNot } from '../models/cql2/operators/logical';
-import { stacRequest } from '../store/utils';
 import { formatKey } from '@radiantearth/stac-fields/helper';
 
 
@@ -274,7 +273,7 @@ export default defineComponent({
   },
   computed: {
     ...mapState(['defaultCollectionSort', 'defaultItemSort', 'searchResultsPerPage', 'maxEntriesPerPage', 'uiLanguage']),
-    ...mapGetters(['canSearchCollections', 'getApiChildrenState', 'supportsConformance']),
+    ...mapGetters(['canSearchCollections', 'getApiChildren', 'supportsConformance']),
     collectionSelectOptions() {
       let taggable = !this.hasAllCollections;
       let isResult = this.collections.length > 0 && !this.hasAllCollections;
@@ -297,7 +296,7 @@ export default defineComponent({
       };
     },
     collectionSearchLink() {
-      return this.parent && this.parent.isCatalogLike && this.parent.getApiCollectionsLink();
+      return this.parent?.isCatalogLike && this.parent.getApiCollectionsLink();
     },
     codeExampleSearchLinks() {
       const toMethodMap = (link) => {
@@ -423,10 +422,7 @@ export default defineComponent({
       return min instanceof Date && max instanceof Date && min.getTime() === max.getTime();
     },
     apiCollectionsState() {
-      if (!this.parent?.isCatalogLike) {
-        return null;
-      }
-      return this.getApiChildrenState(this.parent);
+      return this.getApiChildren(this.parent);
     },
     apiCollectionsFromStore() {
       const list = this.apiCollectionsState?.list;
@@ -561,7 +557,7 @@ export default defineComponent({
       this.collectionsLoadingTimer = setTimeout(async () => {
         try {
           const link = Utils.addFiltersToLink(this.collectionSearchLink, {q: [text]});
-          const response = await stacRequest(this.$store, link);
+          const response = await this.$store.dispatch('request', { link });
           
           // Only set collections if response is valid AND collectionsLoadingTimer has not been reset.
           // If collectionsLoadingTimer has been reset, the result is not relevant anylonger.
@@ -591,7 +587,7 @@ export default defineComponent({
         data.collections = this.collections;
       }
       else if (this.type === 'Global' || this.type === 'Collections') {
-        let response = await stacRequest(this.$store, link);
+        let response = await this.$store.dispatch('request', { link });
         
         if (!isObject(response.data)) {
           return {};
@@ -639,7 +635,7 @@ export default defineComponent({
         .sort((a,b) => collator.compare(a.text, b.text));
     },
     async loadSchemas(link) {
-      let response = await stacRequest(this.$store, link);
+      let response = await this.$store.dispatch('request', { link });
       if (!isObject(response.data)) {
         return;
       }

--- a/src/components/StacLink.vue
+++ b/src/components/StacLink.vue
@@ -133,10 +133,10 @@ export default defineComponent({
       if (this.stac || this.isStacBrowserLink) {
         let href;
         if (this.stac instanceof STAC) {
-          href = this.stac.getBrowserPath();
+          href = this.toBrowserPath(this.stac);
         }
         else {
-          href = this.toBrowserPath(this.link.href);
+          href = this.toBrowserPath(this.link);
         }
         // Normalize to start with a slash for router-link navigation
         if (!href.startsWith('/')) {

--- a/src/components/Tree.vue
+++ b/src/components/Tree.vue
@@ -42,7 +42,8 @@
 import { mapGetters, mapState } from 'vuex';
 import { isObject } from 'stac-js/src/utils.js';
 import { toAbsolute } from 'stac-js/src/http.js';
-import { getDisplayTitle } from '../models/stac';
+import Utils from '../utils';
+import { getDisplayTitle, sortStac } from '../models/stac';
 import { STAC } from 'stac-js';
 
 export default {
@@ -69,7 +70,7 @@ export default {
     };
   },
   computed: {
-    ...mapState(['data', 'apiCatalogPriority']),
+    ...mapState(['data', 'apiCatalogPriority', 'defaultCollectionSort', 'defaultItemSort', 'uiLanguage']),
     ...mapGetters(['getChildren', 'getStac', 'toBrowserPath']),
     onClick() {
       if (!this.to && this.mayHaveChildren) {
@@ -150,7 +151,37 @@ export default {
     },
     childs() {
       if (this.stac?.isCatalogLike) {
-        return this.getChildren(this.stac, this.apiCatalogPriority);
+        const children = this.getChildren(this.stac, this.apiCatalogPriority);
+        if (children.length < 2) {
+          return children;
+        }
+
+        const collectionSort = Utils.parseApiSortParameter(this.defaultCollectionSort);
+        const itemSort = Utils.parseApiSortParameter(this.defaultItemSort);
+
+        const prev = [];
+        const next = [];
+        const items = [];
+        const catalogs = [];
+        for (const child of children) {
+          if (['prev', 'previous'].includes(child?.rel)) {
+            prev.push(child);
+          }
+          else if (child?.rel === 'next') {
+            next.push(child);
+          }
+          else if (child?.rel === 'item' || child?.isItem) {
+            items.push(child);
+          }
+          else {
+            catalogs.push(child);
+          }
+        }
+
+        const sortedCatalogs = collectionSort.direction === 0 ? catalogs : sortStac(catalogs, collectionSort, this.uiLanguage);
+        const sortedItems = itemSort.direction === 0 ? items : sortStac(items, itemSort, this.uiLanguage);
+
+        return prev.concat(sortedCatalogs, sortedItems, next);
       }
       return [];
     },

--- a/src/components/Tree.vue
+++ b/src/components/Tree.vue
@@ -1,7 +1,11 @@
 <template>
   <ul class="tree" v-visible="load">
     <li>
-      <b-button v-if="pagination" size="sm" variant="light" disabled>
+      <b-button v-if="canLoadMore" size="sm" variant="light" v-visible.300="loadNextPage" @click="loadNextPage()">
+        <b-spinner v-if="loadingMore" small :label="$t('loading')" />
+        <b-icon-three-dots v-else />
+      </b-button>
+      <b-button v-else-if="pagination" size="sm" variant="light" disabled>
         <b-icon-three-dots />
       </b-button>
       <template v-else-if="mayHaveChildren">
@@ -71,7 +75,7 @@ export default {
   },
   computed: {
     ...mapState(['data', 'apiCatalogPriority', 'defaultCollectionSort', 'defaultItemSort', 'uiLanguage']),
-    ...mapGetters(['getChildren', 'getStac', 'toBrowserPath']),
+    ...mapGetters(['getApiChildren', 'getChildren', 'getStac', 'isApiChildrenLoading', 'toBrowserPath']),
     onClick() {
       if (!this.to && this.mayHaveChildren) {
         return this.toggle;
@@ -142,7 +146,7 @@ export default {
     },
     title() {
       if (this.pagination) {
-        return this.$t('tree.moreCollectionPagesAvailable');
+        return this.canLoadMore ? this.$t('catalogs.loadMore') : this.$t('tree.moreCollectionPagesAvailable');
       }
       return getDisplayTitle([this.item, this.stac]);
     },
@@ -199,6 +203,12 @@ export default {
     },
     pagination() {
       return ['next', 'prev', 'previous'].includes(this.item.rel);
+    },
+    canLoadMore() {
+      return this.item.rel === 'next' && this.getApiChildren(this.parent)?.type === 'collections';
+    },
+    loadingMore() {
+      return this.isApiChildrenLoading(this.parent);
     }
   },
   watch: {
@@ -219,6 +229,19 @@ export default {
   methods: {
     showMore() {
       this.chunk++;
+    },
+    async loadNextPage(visible = true) {
+      if (!visible || this.loadingMore) {
+        return;
+      }
+      try {
+        await this.$store.dispatch('loadNextApiCollections', { stac: this.parent, next: true });
+      } catch (error) {
+        this.$store.commit('showGlobalError', {
+          error,
+          message: this.$t('errors.loadApiCollectionsFailed')
+        });
+      }
     },
     load(visible) {
       if (!this.stac && this.link && !this.pagination) {

--- a/src/components/Tree.vue
+++ b/src/components/Tree.vue
@@ -42,7 +42,7 @@
 import { mapGetters, mapState } from 'vuex';
 import { isObject } from 'stac-js/src/utils.js';
 import { toAbsolute } from 'stac-js/src/http.js';
-import { getDisplayTitle, Collection } from '../models/stac';
+import { getChildren, getDisplayTitle, setApiDataListener } from '../models/stac';
 import { STAC } from 'stac-js';
 
 export default {
@@ -82,7 +82,7 @@ export default {
       if (this.pagination) {
         return null;
       }
-      else if (this.item instanceof STAC) {
+      else if (this.item.isSTAC) {
         let stac = this.getStac(this.item.getAbsoluteUrl());
         if (!this.loading && stac) {
           return stac;
@@ -177,11 +177,11 @@ export default {
     stac: {
       immediate: true,
       handler(newStac, oldStac) {
-        if (newStac instanceof Collection) {
-          newStac.setApiDataListener('tree', () => this.updateChilds());
+        if (newStac?.isCatalogLike) {
+          setApiDataListener(newStac, 'tree', () => this.updateChilds());
         }
-        if (oldStac instanceof Collection) {
-          oldStac.setApiDataListener('tree');
+        if (oldStac?.isCatalogLike) {
+          setApiDataListener(oldStac, 'tree');
         }
         this.updateChilds();
       }
@@ -194,8 +194,8 @@ export default {
   },
   methods: {
     updateChilds() {
-      if (this.stac && this.stac.isCatalogLike) {
-        this.childs = this.stac.getChildren(this.apiCatalogPriority);
+      if (this.stac?.isCatalogLike) {
+        this.childs = getChildren(this.stac, this.apiCatalogPriority);
       }
       else {
         this.childs = [];

--- a/src/components/Tree.vue
+++ b/src/components/Tree.vue
@@ -71,7 +71,7 @@ export default {
   },
   computed: {
     ...mapState(['data', 'apiCatalogPriority']),
-    ...mapGetters(['getStac']),
+    ...mapGetters(['getStac', 'toBrowserPath']),
     onClick() {
       if (!this.to && this.mayHaveChildren) {
         return this.toggle;
@@ -129,14 +129,14 @@ export default {
       }
       if (this.pagination) {
         if (this.parent && (!this.data || this.parent.getAbsoluteUrl() !== this.data.getAbsoluteUrl())) {
-          return this.parent.getBrowserPath();
+          return this.toBrowserPath(this.parent);
         }
         else {
           return null;
         }
       }
       else if (this.stac instanceof STAC) {
-        return this.stac.getBrowserPath();
+        return this.toBrowserPath(this.stac);
       }
       return null;
     },

--- a/src/components/Tree.vue
+++ b/src/components/Tree.vue
@@ -42,7 +42,7 @@
 import { mapGetters, mapState } from 'vuex';
 import { isObject } from 'stac-js/src/utils.js';
 import { toAbsolute } from 'stac-js/src/http.js';
-import { getChildren, getDisplayTitle, setApiDataListener } from '../models/stac';
+import { getDisplayTitle } from '../models/stac';
 import { STAC } from 'stac-js';
 
 export default {
@@ -65,13 +65,12 @@ export default {
     return {
       expanded: false,
       loading: false,
-      chunk: 1,
-      childs: []
+      chunk: 1
     };
   },
   computed: {
     ...mapState(['data', 'apiCatalogPriority']),
-    ...mapGetters(['getStac', 'toBrowserPath']),
+    ...mapGetters(['getChildren', 'getStac', 'toBrowserPath']),
     onClick() {
       if (!this.to && this.mayHaveChildren) {
         return this.toggle;
@@ -149,6 +148,12 @@ export default {
     hasMore() {
       return this.childs.length > this.shownChilds.length;
     },
+    childs() {
+      if (this.stac?.isCatalogLike) {
+        return this.getChildren(this.stac, this.apiCatalogPriority);
+      }
+      return [];
+    },
     shownChilds() {
       return this.childs.slice(0, this.chunk * 50);
     },
@@ -173,18 +178,6 @@ export default {
           this.expanded = true;
         }
       }
-    },
-    stac: {
-      immediate: true,
-      handler(newStac, oldStac) {
-        if (newStac?.isCatalogLike) {
-          setApiDataListener(newStac, 'tree', () => this.updateChilds());
-        }
-        if (oldStac?.isCatalogLike) {
-          setApiDataListener(oldStac, 'tree');
-        }
-        this.updateChilds();
-      }
     }
   },
   created() {
@@ -193,14 +186,6 @@ export default {
     }
   },
   methods: {
-    updateChilds() {
-      if (this.stac?.isCatalogLike) {
-        this.childs = getChildren(this.stac, this.apiCatalogPriority);
-      }
-      else {
-        this.childs = [];
-      }
-    },
     showMore() {
       this.chunk++;
     },

--- a/src/components/Validation.vue
+++ b/src/components/Validation.vue
@@ -10,6 +10,7 @@
 <script>
 import { STAC } from 'stac-js';
 import validateSTAC from 'stac-node-validator';
+import { mapGetters } from 'vuex';
 
 export default {
   name: "Validation",
@@ -30,9 +31,10 @@ export default {
     };
   },
   computed: {
+    ...mapGetters(['toBrowserPath']),
     validationLink() {
       if (this.data instanceof STAC) {
-        return '/validation' + this.data.getBrowserPath();
+        return '/validation' + this.toBrowserPath(this.data);
       }
       else {
         return null;

--- a/src/components/maps/MapMixin.js
+++ b/src/components/maps/MapMixin.js
@@ -7,7 +7,6 @@ import { defaults } from 'ol/interaction/defaults';
 import ZoomControl from 'ol/control/Zoom.js';
 import AttributionControl from 'ol/control/Attribution.js';
 import FullScreenControl from 'ol/control/FullScreen.js';
-import { stacRequest } from '../../store/utils';
 
 import configureBasemap from '../../../basemaps.config';
 import CONFIG from '../../merged-config';
@@ -35,7 +34,7 @@ export default {
         useTileLayerAsFallback: this.useTileLayerAsFallback,
         getSourceOptions: this.getMapSourceOptions,
         httpRequestFn: async (url, responseType) => {
-          const response = await stacRequest(this.$store, url, {responseType});
+          const response = await this.$store.dispatch('request', { link: url, axiosOptions: { responseType } });
           return response.data;
         },
       };

--- a/src/models/stac.js
+++ b/src/models/stac.js
@@ -4,44 +4,19 @@ import Utils from '../utils';
 import { hasText, isObject } from 'stac-js/src/utils.js';
 import { toAbsolute } from 'stac-js/src/http.js';
 
-const apiChildrenState = new WeakMap();
-const apiChildrenListeners = new WeakMap();
-
-function ensureApiChildren(stac) {
-  let state = apiChildrenState.get(stac);
-  if (!state) {
-    state = {
-      list: [],
-      prev: false,
-      next: false
-    };
-    apiChildrenState.set(stac, state);
-  }
-  return state;
-}
-
-function ensureApiChildrenListeners(stac) {
-  let listeners = apiChildrenListeners.get(stac);
-  if (!listeners) {
-    listeners = {};
-    apiChildrenListeners.set(stac, listeners);
-  }
-  return listeners;
-}
-
 function setInternal(stac, key, value) {
   const internalKey = '_' + key;
   stac[internalKey] = value;
   stac._privateKeys.push(internalKey);
 }
 
-export function createSTAC(data, url = null, preprocess = null) {
+export function createSTAC(data, url = null) {
   // Uncomment this line if the old checksum: fields should be converted
   // This is usually not needed so it's not enabled by default to shrink the bundle size
   // Migrate.enableMultihash(require('multihashes'));
 
   // Migrate STAC to latest version
-  let original = JSON.parse(JSON.stringify(data)); // todo: use structuredClone()
+  let original = data._original ?? structuredClone(data);
   data = Migrate.stac(data, false);
 
   // Create stac-js object based on STAC type
@@ -66,19 +41,8 @@ export function createSTAC(data, url = null, preprocess = null) {
   if (obj.isApiCollection) {
     obj.getAll().forEach(child => setInternal(child, 'incomplete', true));
   }
-  setInternal(obj, 'original', original);
   // todo: Should we set original for API children?
-
-  // Preprocess the STAC object if a preprocess function is provided
-  if (preprocess) {
-    if (obj.isSTAC) {
-      obj = preprocess(obj);
-    }
-    else if (obj.isApiCollection) {
-      const key = obj.isCollectionCollection ? 'collections' : 'features';
-      obj[key] = obj[key].map(child => preprocess(child));
-    }
-  }
+  setInternal(obj, 'original', original);
   return obj;
 }
 
@@ -160,76 +124,4 @@ export function sortStac(entities, sort, uiLanguage) {
     return sorted.reverse();
   }
   return sorted;
-}
-
-export function getChildren(stac, priority = null) {
-  if (!stac.isCatalogLike) {
-    return [];
-  }
-
-  const apiChildren = ensureApiChildren(stac);
-
-  let showCollections = !priority || priority === 'collections';
-  let showChilds = !priority || priority === 'childs';
-
-  let children = [];
-  if (showCollections && apiChildren.prev) {
-    children.push(apiChildren.prev);
-  }
-  if (showCollections && apiChildren.list.length > 0) {
-    children = apiChildren.list.slice(0);
-  }
-  if (showChilds) {
-    children = addMissingChildren(children, stac).concat(stac.getLinksWithRels(['item']));
-  }
-  if (showCollections && apiChildren.next) {
-    children.push(apiChildren.next);
-  }
-  return children;
-}
-
-export function getApiChildrenState(stac) {
-  if (!stac.isCatalogLike) {
-    return null;
-  }
-  return ensureApiChildren(stac);
-}
-
-export function setApiDataListener(stac, id, listener = null) {
-  if (!stac.isCatalogLike || typeof id !== 'string' || id.length === 0) {
-    return;
-  }
-
-  const listeners = ensureApiChildrenListeners(stac);
-  if (typeof listener === 'function') {
-    listeners[id] = listener;
-  }
-  else {
-    delete listeners[id];
-  }
-}
-
-export function setApiData(stac, list, next = null, prev = null) {
-  if (!stac.isCatalogLike) {
-    return;
-  }
-
-  const apiChildren = ensureApiChildren(stac);
-  if (prev) {
-    apiChildren.prev = prev;
-  }
-  if (next) {
-    apiChildren.next = next;
-  }
-  apiChildren.list = Array.isArray(list) ? list : [];
-
-  const listeners = ensureApiChildrenListeners(stac);
-  for (let id in listeners) {
-    try {
-      listeners[id](apiChildren);
-    }
-    catch (error) {
-      console.error(error);
-    }
-  }
 }

--- a/src/models/stac.js
+++ b/src/models/stac.js
@@ -13,7 +13,8 @@ import { hasText, isObject } from 'stac-js/src/utils.js';
 import { toAbsolute } from 'stac-js/src/http.js';
 
 
-export function createSTAC(data, url, path, migrate = true, updateVersionNumber = false) {
+export function createSTAC(data, url, migrate = true, updateVersionNumber = false) {
+  // Migrate STAC to latest version
   if (migrate) {
     // Uncomment this line if the old checksum: fields should be converted
     // This is usually not needed so it's not enabled by default to shrink the bundle size
@@ -21,24 +22,26 @@ export function createSTAC(data, url, path, migrate = true, updateVersionNumber 
     data._original = data;
     data = Migrate.stac(data, updateVersionNumber);
   }
+  // Create stac-js object based on STAC type
   let obj;
   if (data.type === 'Feature') {
-    obj = new Item(data, url, path);
+    obj = new Item(data, url);
   }
   else if (data.type === 'FeatureCollection') {
     // todo: convert inner collections to stac-js as well
-    obj = new ItemCollection(data, url, path);
+    obj = new ItemCollection(data, url);
   }
   else if (data.type === 'Collection' || (!data.type && typeof data.extent !== 'undefined' && typeof data.license !== 'undefined')) {
-    obj = new Collection(data, url, path);
+    obj = new Collection(data, url);
   }
   else if (!data.type && Array.isArray(data.collections)) {
     // todo: convert inner collections to stac-js as well
-    obj = new CollectionCollection(data, url, path);
+    obj = new CollectionCollection(data, url);
   }
   else {
-    obj = new Catalog(data, url, path);
+    obj = new Catalog(data, url);
   }
+  // Flag the _original property as private for internal stac-js purposes
   if (data._original) {
     obj._privateKeys.push('_original');
   }
@@ -149,39 +152,14 @@ function getChildren(stac, priority = null) {
   return children;
 }
 
-export class ItemCollection extends BaseItemCollection {
+export class ItemCollection extends BaseItemCollection {}
 
-  constructor(data, url, path) {
-    super(data, url);
-    this._path = path;
-    this._privateKeys.push('_path');
-  }
-
-  getBrowserPath() {
-    return this._path;
-  }
-
-}
-
-export class CollectionCollection extends BaseCollectionCollection {
-
-  constructor(data, url, path) {
-    super(data, url);
-    this._path = path;
-    this._privateKeys.push('_path');
-  }
-
-  getBrowserPath() {
-    return this._path;
-  }
-
-}
+export class CollectionCollection extends BaseCollectionCollection {}
 
 export class Collection extends BaseCollection {
 
-  constructor(data, url, path) {
+  constructor(data, url) {
     super(data, url);
-    this._path = path;
     this._incomplete = false;
     this._apiChildrenListeners = {};
     this._apiChildren = {
@@ -189,11 +167,7 @@ export class Collection extends BaseCollection {
       prev: false,
       next: false
     };
-    this._privateKeys.push('_path', '_incomplete', '_apiChildrenListeners', '_apiChildren');
-  }
-
-  getBrowserPath() {
-    return this._path;
+    this._privateKeys.push('_incomplete', '_apiChildrenListeners', '_apiChildren');
   }
 
   getChildren(priority = null) {
@@ -231,9 +205,8 @@ export class Collection extends BaseCollection {
 
 export class Catalog extends BaseCatalog {
 
-  constructor(data, url, path) {
+  constructor(data, url) {
     super(data, url);
-    this._path = path;
     this._incomplete = false;
     this._apiChildrenListeners = {};
     this._apiChildren = {
@@ -241,11 +214,7 @@ export class Catalog extends BaseCatalog {
       prev: false,
       next: false
     };
-    this._privateKeys.push('_path', '_incomplete', '_apiChildrenListeners', '_apiChildren');
-  }
-
-  getBrowserPath() {
-    return this._path;
+    this._privateKeys.push('_incomplete', '_apiChildrenListeners', '_apiChildren');
   }
 
   getChildren(priority = null) {
@@ -283,15 +252,10 @@ export class Catalog extends BaseCatalog {
 
 export class Item extends BaseItem {
 
-  constructor(data, url, path) {
+  constructor(data, url) {
     super(data, url);
-    this._path = path;
     this._incomplete = false;
-    this._privateKeys.push('_path', '_incomplete');
-  }
-
-  getBrowserPath() {
-    return this._path;
+    this._privateKeys.push('_incomplete');
   }
 
 }

--- a/src/models/stac.js
+++ b/src/models/stac.js
@@ -47,11 +47,15 @@ export function createSTAC(data, url = null, store = null) {
 
   // Set stac-browser internal properties
   if (obj.isApiCollection) {
-    obj.getAll().forEach(child => setInternal(child, 'incomplete', true));
+    const originals = obj.isCollectionCollection ? original.collections : original.features;
+    obj.getAll().forEach((child, i) => {
+      setInternal(child, 'incomplete', true);
+      setInternal(child, 'original', originals[i]);
+    });
   }
-  // todo: Should we set original for API children?
   setInternal(obj, 'original', original);
 
+  // Preprocess STAC objects
   if (store && obj.isItemCollection) {
     obj.features = obj.features.map(item => processSTAC(item, store));
   }

--- a/src/models/stac.js
+++ b/src/models/stac.js
@@ -3,6 +3,7 @@ import Migrate from '@radiantearth/stac-migrate';
 import Utils from '../utils';
 import { hasText, isObject } from 'stac-js/src/utils.js';
 import { toAbsolute } from 'stac-js/src/http.js';
+import { markRaw } from 'vue';
 
 function setInternal(stac, key, value) {
   const internalKey = '_' + key;
@@ -10,7 +11,14 @@ function setInternal(stac, key, value) {
   stac._privateKeys.push(internalKey);
 }
 
-export function createSTAC(data, url = null) {
+export function processSTAC(stac, store) {
+  if (typeof store.state.preprocessSTAC === 'function') {
+    stac = store.state.preprocessSTAC(stac, store.state, store.getters);
+  }
+  return markRaw(stac);
+}
+
+export function createSTAC(data, url = null, store = null) {
   // Uncomment this line if the old checksum: fields should be converted
   // This is usually not needed so it's not enabled by default to shrink the bundle size
   // Migrate.enableMultihash(require('multihashes'));
@@ -43,6 +51,17 @@ export function createSTAC(data, url = null) {
   }
   // todo: Should we set original for API children?
   setInternal(obj, 'original', original);
+
+  if (store && obj.isItemCollection) {
+    obj.features = obj.features.map(item => processSTAC(item, store));
+  }
+  else if (store && obj.isCollectionCollection) {
+    obj.collections = obj.collections.map(collection => processSTAC(collection, store));
+  }
+  else if (store) {
+    obj = processSTAC(obj, store);
+  }
+
   return obj;
 }
 

--- a/src/models/stac.js
+++ b/src/models/stac.js
@@ -1,53 +1,83 @@
-import {
-  Catalog as BaseCatalog,
-  Collection as BaseCollection,
-  Item,
-  ItemCollection,
-  CollectionCollection,
-  STAC,
-  STACReference
-} from 'stac-js';
+import { Catalog, Collection, Item, ItemCollection, CollectionCollection, STAC, STACReference } from 'stac-js';
 import Migrate from '@radiantearth/stac-migrate';
-import Utils from "../utils";
+import Utils from '../utils';
 import { hasText, isObject } from 'stac-js/src/utils.js';
 import { toAbsolute } from 'stac-js/src/http.js';
 
+const apiChildrenState = new WeakMap();
+const apiChildrenListeners = new WeakMap();
 
-export function createSTAC(data, url, incomplete = false, migrate = true, updateVersionNumber = false) {
-  // Migrate STAC to latest version
-  if (migrate) {
-    // Uncomment this line if the old checksum: fields should be converted
-    // This is usually not needed so it's not enabled by default to shrink the bundle size
-    // Migrate.enableMultihash(require('multihashes'));
-    data._original = data;
-    data = Migrate.stac(data, updateVersionNumber);
+function ensureApiChildren(stac) {
+  let state = apiChildrenState.get(stac);
+  if (!state) {
+    state = {
+      list: [],
+      prev: false,
+      next: false
+    };
+    apiChildrenState.set(stac, state);
   }
+  return state;
+}
+
+function ensureApiChildrenListeners(stac) {
+  let listeners = apiChildrenListeners.get(stac);
+  if (!listeners) {
+    listeners = {};
+    apiChildrenListeners.set(stac, listeners);
+  }
+  return listeners;
+}
+
+function setInternal(stac, key, value) {
+  const internalKey = '_' + key;
+  stac[internalKey] = value;
+  stac._privateKeys.push(internalKey);
+}
+
+export function createSTAC(data, url = null, preprocess = null) {
+  // Uncomment this line if the old checksum: fields should be converted
+  // This is usually not needed so it's not enabled by default to shrink the bundle size
+  // Migrate.enableMultihash(require('multihashes'));
+
+  // Migrate STAC to latest version
+  let original = JSON.parse(JSON.stringify(data)); // todo: use structuredClone()
+  data = Migrate.stac(data, false);
+
   // Create stac-js object based on STAC type
   let obj;
   if (data.type === 'Feature') {
     obj = new Item(data, url);
   }
   else if (data.type === 'FeatureCollection') {
-    // todo: convert inner collections to stac-js as well
     obj = new ItemCollection(data, url);
   }
   else if (data.type === 'Collection' || (!data.type && typeof data.extent !== 'undefined' && typeof data.license !== 'undefined')) {
     obj = new Collection(data, url);
   }
   else if (!data.type && Array.isArray(data.collections)) {
-    // todo: convert inner collections to stac-js as well
     obj = new CollectionCollection(data, url);
   }
   else {
     obj = new Catalog(data, url);
   }
-  // Flag the _original property as private for internal stac-js purposes
-  if (data._original) {
-    obj._privateKeys.push('_original');
+
+  // Set stac-browser internal properties
+  if (obj.isApiCollection) {
+    obj.getAll().forEach(child => setInternal(child, 'incomplete', true));
   }
-  if (incomplete) {
-    obj._incomplete = true;
-    obj._privateKeys.push('_incomplete');
+  setInternal(obj, 'original', original);
+  // todo: Should we set original for API children?
+
+  // Preprocess the STAC object if a preprocess function is provided
+  if (preprocess) {
+    if (obj.isSTAC) {
+      obj = preprocess(obj);
+    }
+    else if (obj.isApiCollection) {
+      const key = obj.isCollectionCollection ? 'collections' : 'features';
+      obj[key] = obj[key].map(child => preprocess(child));
+    }
   }
   return obj;
 }
@@ -132,120 +162,74 @@ export function sortStac(entities, sort, uiLanguage) {
   return sorted;
 }
 
-function getChildren(stac, priority = null) {
+export function getChildren(stac, priority = null) {
   if (!stac.isCatalogLike) {
     return [];
   }
+
+  const apiChildren = ensureApiChildren(stac);
 
   let showCollections = !priority || priority === 'collections';
   let showChilds = !priority || priority === 'childs';
 
   let children = [];
-  if (showCollections && stac._apiChildren.prev) {
-    children.push(stac._apiChildren.prev);
+  if (showCollections && apiChildren.prev) {
+    children.push(apiChildren.prev);
   }
-  if (showCollections && stac._apiChildren.list.length > 0) {
-    children = stac._apiChildren.list.slice(0);
+  if (showCollections && apiChildren.list.length > 0) {
+    children = apiChildren.list.slice(0);
   }
   if (showChilds) {
     children = addMissingChildren(children, stac).concat(stac.getLinksWithRels(['item']));
   }
-  if (showCollections && stac._apiChildren.next) {
-    children.push(stac._apiChildren.next);
+  if (showCollections && apiChildren.next) {
+    children.push(apiChildren.next);
   }
   return children;
 }
 
-export class Collection extends BaseCollection {
-
-  constructor(data, url) {
-    super(data, url);
-    this._apiChildrenListeners = {};
-    this._apiChildren = {
-      list: [],
-      prev: false,
-      next: false
-    };
-    this._privateKeys.push('_apiChildrenListeners', '_apiChildren');
+export function getApiChildrenState(stac) {
+  if (!stac.isCatalogLike) {
+    return null;
   }
-
-  getChildren(priority = null) {
-    return getChildren(this, priority);
-  }
-
-  setApiDataListener(id, listener = null) {
-    if (typeof listener === 'function') {
-      this._apiChildrenListeners[id] = listener;
-    }
-    else {
-      delete this._apiChildrenListeners[id];
-    }
-  }
-
-  setApiData(list, next = null, prev = null) {
-    if (prev) {
-      this._apiChildren.prev = prev;
-    }
-    if (next) {
-      this._apiChildren.next = next;
-    }
-    this._apiChildren.list = list;
-
-    for (let id in this._apiChildrenListeners) {
-      try {
-        this._apiChildrenListeners[id](this._apiChildren);
-      } catch (error) {
-        console.error(error);
-      }
-    }
-  }
-
+  return ensureApiChildren(stac);
 }
 
-export class Catalog extends BaseCatalog {
-
-  constructor(data, url) {
-    super(data, url);
-    this._apiChildrenListeners = {};
-    this._apiChildren = {
-      list: [],
-      prev: false,
-      next: false
-    };
-    this._privateKeys.push('_apiChildrenListeners', '_apiChildren');
+export function setApiDataListener(stac, id, listener = null) {
+  if (!stac.isCatalogLike || typeof id !== 'string' || id.length === 0) {
+    return;
   }
 
-  getChildren(priority = null) {
-    return getChildren(this, priority);
+  const listeners = ensureApiChildrenListeners(stac);
+  if (typeof listener === 'function') {
+    listeners[id] = listener;
   }
-
-  setApiDataListener(id, listener = null) {
-    if (typeof listener === 'function') {
-      this._apiChildrenListeners[id] = listener;
-    }
-    else {
-      delete this._apiChildrenListeners[id];
-    }
+  else {
+    delete listeners[id];
   }
-
-  setApiData(list, next = null, prev = null) {
-    if (prev) {
-      this._apiChildren.prev = prev;
-    }
-    if (next) {
-      this._apiChildren.next = next;
-    }
-    this._apiChildren.list = list;
-
-    for (let id in this._apiChildrenListeners) {
-      try {
-        this._apiChildrenListeners[id](this._apiChildren);
-      } catch (error) {
-        console.error(error);
-      }
-    }
-  }
-
 }
 
-export { CollectionCollection, Item, ItemCollection };
+export function setApiData(stac, list, next = null, prev = null) {
+  if (!stac.isCatalogLike) {
+    return;
+  }
+
+  const apiChildren = ensureApiChildren(stac);
+  if (prev) {
+    apiChildren.prev = prev;
+  }
+  if (next) {
+    apiChildren.next = next;
+  }
+  apiChildren.list = Array.isArray(list) ? list : [];
+
+  const listeners = ensureApiChildrenListeners(stac);
+  for (let id in listeners) {
+    try {
+      listeners[id](apiChildren);
+    }
+    catch (error) {
+      console.error(error);
+    }
+  }
+}

--- a/src/models/stac.js
+++ b/src/models/stac.js
@@ -1,9 +1,9 @@
 import {
   Catalog as BaseCatalog,
   Collection as BaseCollection,
-  Item as BaseItem,
-  ItemCollection as BaseItemCollection,
-  CollectionCollection as BaseCollectionCollection,
+  Item,
+  ItemCollection,
+  CollectionCollection,
   STAC,
   STACReference
 } from 'stac-js';
@@ -13,7 +13,7 @@ import { hasText, isObject } from 'stac-js/src/utils.js';
 import { toAbsolute } from 'stac-js/src/http.js';
 
 
-export function createSTAC(data, url, migrate = true, updateVersionNumber = false) {
+export function createSTAC(data, url, incomplete = false, migrate = true, updateVersionNumber = false) {
   // Migrate STAC to latest version
   if (migrate) {
     // Uncomment this line if the old checksum: fields should be converted
@@ -44,6 +44,10 @@ export function createSTAC(data, url, migrate = true, updateVersionNumber = fals
   // Flag the _original property as private for internal stac-js purposes
   if (data._original) {
     obj._privateKeys.push('_original');
+  }
+  if (incomplete) {
+    obj._incomplete = true;
+    obj._privateKeys.push('_incomplete');
   }
   return obj;
 }
@@ -152,22 +156,17 @@ function getChildren(stac, priority = null) {
   return children;
 }
 
-export class ItemCollection extends BaseItemCollection {}
-
-export class CollectionCollection extends BaseCollectionCollection {}
-
 export class Collection extends BaseCollection {
 
   constructor(data, url) {
     super(data, url);
-    this._incomplete = false;
     this._apiChildrenListeners = {};
     this._apiChildren = {
       list: [],
       prev: false,
       next: false
     };
-    this._privateKeys.push('_incomplete', '_apiChildrenListeners', '_apiChildren');
+    this._privateKeys.push('_apiChildrenListeners', '_apiChildren');
   }
 
   getChildren(priority = null) {
@@ -207,14 +206,13 @@ export class Catalog extends BaseCatalog {
 
   constructor(data, url) {
     super(data, url);
-    this._incomplete = false;
     this._apiChildrenListeners = {};
     this._apiChildren = {
       list: [],
       prev: false,
       next: false
     };
-    this._privateKeys.push('_incomplete', '_apiChildrenListeners', '_apiChildren');
+    this._privateKeys.push('_apiChildrenListeners', '_apiChildren');
   }
 
   getChildren(priority = null) {
@@ -250,12 +248,4 @@ export class Catalog extends BaseCatalog {
 
 }
 
-export class Item extends BaseItem {
-
-  constructor(data, url) {
-    super(data, url);
-    this._incomplete = false;
-    this._privateKeys.push('_incomplete');
-  }
-
-}
+export { CollectionCollection, Item, ItemCollection };

--- a/src/store/auth.js
+++ b/src/store/auth.js
@@ -75,7 +75,7 @@ export default function getStore(router) {
             await cx.dispatch('executeActions');
           }
           else {
-            cx.commit('resetActions');
+            await cx.dispatch('cancelActions');
           }
         };
 
@@ -102,8 +102,11 @@ export default function getStore(router) {
           handleAuthError(cx, error);
         }
       },
-      async abortLogin(cx) { // eslint-disable-line require-await
+      async abortLogin(cx) {
         cx.commit('setInProgress', false);
+        // The user actively declined to log in, so don't keep the pending
+        // actions around for a (potentially much later) login.
+        await cx.dispatch('cancelActions');
       },
       async requestLogout(cx) {
         if (!cx.getters.isLoggedIn) {
@@ -135,15 +138,33 @@ export default function getStore(router) {
           cookie.setItem(intent.cookie.key, intent.cookie.value);
         }
       },
+      // Actions are either plain functions or objects with a `run` function
+      // and an optional `cancel` function (see cancelActions).
       async executeActions(cx) { // eslint-disable-line require-await
-        for (let callback of cx.state.actions) {
+        for (let action of cx.state.actions) {
+          const run = typeof action === 'function' ? action : action.run;
           try {
-            const p = callback();
+            const p = run();
             if (p instanceof Promise) {
               p.catch(error => handleAuthError(cx, error));
             }
           } catch (error) {
             handleAuthError(cx, error);
+          }
+        }
+        cx.commit('resetActions');
+      },
+      // Discards the pending actions, e.g. when the user aborts the login or logs out.
+      // Notifies the actions through their `cancel` function so that pending
+      // promises can settle instead of hanging around forever.
+      async cancelActions(cx) { // eslint-disable-line require-await
+        for (let action of cx.state.actions) {
+          if (typeof action.cancel === 'function') {
+            try {
+              action.cancel();
+            } catch (error) {
+              console.error(error);
+            }
           }
         }
         cx.commit('resetActions');

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -6,7 +6,7 @@ import urijs from 'urijs';
 import i18n, { loadMessages, detectDataLanguage, updateExternals } from '../i18n';
 import Utils, { BrowserError } from '../utils';
 import { toAbsolute } from 'stac-js/src/http.js';
-import { addMissingChildren, getDisplayTitle, createSTAC, setApiData } from '../models/stac';
+import { addMissingChildren, getDisplayTitle, createSTAC } from '../models/stac';
 import { CatalogLike, STAC } from 'stac-js';
 
 import auth from './auth.js';
@@ -15,12 +15,25 @@ import { getBest } from 'stac-js/src/locales';
 import { TYPES } from "../components/ApiCapabilitiesMixin";
 import BrowserStorage from "../browser-store.js";
 
+function updateApiChildrenState(state, stac, list, next = false, prev = false) {
+  if (!(stac instanceof STAC) || !stac.isCatalogLike) {
+    return;
+  }
+  const key = stac.getAbsoluteUrl();
+  state.apiChildren[key] = {
+    list: Array.isArray(list) ? list : [],
+    prev: prev || false,
+    next: next || false
+  };
+}
+
 function getStore(config, router) {
   // Local settings (e.g. for currently loaded STAC entity)
   const localDefaults = () => ({
     url: '',
     page: null, // Function that returns title and optionally description of the current page as object
     data: null,
+    apiChildren: {},
     loading: true,
     parents: null,
     globalError: null,
@@ -273,13 +286,48 @@ function getStore(config, router) {
         }
         return catalogs;
       },
+      getApiChildrenState: state => stac => {
+        if (!(stac instanceof STAC) || !stac.isCatalogLike) {
+          return null;
+        }
+        return state.apiChildren[stac.getAbsoluteUrl()] || {
+          list: [],
+          prev: false,
+          next: false
+        };
+      },
+      getChildren: (state, getters) => (stac, priority = null) => {
+        if (!(stac instanceof STAC) || !stac.isCatalogLike) {
+          return [];
+        }
+
+        const apiChildren = getters.getApiChildrenState(stac);
+        const showCollections = !priority || priority === 'collections';
+        const showChilds = !priority || priority === 'childs';
+
+        let catalogEntries = [];
+        if (showCollections && apiChildren.list.length > 0) {
+          catalogEntries = apiChildren.list.slice(0);
+        }
+        let children = catalogEntries;
+        if (showChilds) {
+          children = addMissingChildren(catalogEntries, stac).concat(stac.getLinksWithRels(['item']));
+        }
+        if (showCollections && apiChildren.prev) {
+          children = [apiChildren.prev].concat(children);
+        }
+        if (showCollections && apiChildren.next) {
+          children.push(apiChildren.next);
+        }
+        return children;
+      },
 
       toBrowserPath: (state, getters) => ref => {
         let url = ref;
         if (isObject(ref)) {
           if (typeof ref.getAbsoluteUrl === 'function') { // stac-js object
             url = ref.getAbsoluteUrl();
-          } else if (typeof ref.toString === 'function') { // urijs object
+          } else if (ref instanceof urijs) { // urijs object
             url = ref.toString();
           } else if (ref.href) { // plain STAC Link object
             url = ref.href;
@@ -602,6 +650,9 @@ function getStore(config, router) {
           state.apiItemsLoading[collectionId] = true;
         }
       },
+      setApiChildrenData(state, { stac, list, next = null, prev = null }) {
+        updateApiChildrenState(state, stac, list, next, prev);
+      },
       setApiItems(state, { data, stac, show }) {
         if (!isObject(data) || !Array.isArray(data.features)) {
           return;
@@ -629,7 +680,7 @@ function getStore(config, router) {
 
         if (stac instanceof STAC) {
           // ToDo: Prev link only required when state.apiItems is not cached(?) -> cache apiItems?
-          setApiData(stac, apiItems, pages.next, pages.prev);
+          updateApiChildrenState(state, stac, apiItems, pages.next, pages.prev);
         }
       },
       addApiCollections(state, { data, stac, show, searching = false }) {
@@ -645,7 +696,7 @@ function getStore(config, router) {
           state.apiCollections = state.apiCollections.concat(collections);
         }
         if (stac instanceof STAC && !searching) {
-          setApiData(stac, collections, nextLink);
+          updateApiChildrenState(state, stac, collections, nextLink);
         }
       },
       resetApiCollections(state) {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -966,8 +966,7 @@ function getStore(config, router) {
                   return data;
                 }
                 else {
-                  data = createSTAC(item, url);
-                  data._incomplete = true;
+                  data = createSTAC(item, url, true);
                   cx.commit('loaded', { data, url });
                   return data;
                 }
@@ -1075,8 +1074,7 @@ function getStore(config, router) {
                 return data;
               }
               else {
-                data = createSTAC(collection, url);
-                data._incomplete = true;
+                data = createSTAC(collection, url, true);
                 cx.commit('loaded', { data, url });
                 return data;
               }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -10,7 +10,7 @@ import { addMissingChildren, getDisplayTitle, createSTAC } from '../models/stac'
 import { CatalogLike, STAC } from 'stac-js';
 
 import auth from './auth.js';
-import { addQueryIfNotExists, hasAuthority, isAuthenticationError, Loading, processSTAC, stacRequest, stacRequestOptions } from './utils';
+import { addQueryIfNotExists, hasAuthority, isAuthenticationError, Loading, stacRequest, stacRequestOptions } from './utils';
 import { getBest } from 'stac-js/src/locales';
 import { TYPES } from "../components/ApiCapabilitiesMixin";
 import BrowserStorage from "../browser-store.js";
@@ -329,9 +329,9 @@ function getStore(config, router) {
             url = ref.getAbsoluteUrl();
           } else if (ref instanceof urijs) { // urijs object
             url = ref.toString();
-          } else if (ref.href) { // plain STAC Link object
+          } else if (hasText(ref.href)) { // plain STAC Link object
             url = ref.href;
-          }	else {
+          } else {
             throw new Error('Invalid reference provided to toBrowserPath. Must be a stac-js object, URI object or string URL.');
           }
         }
@@ -580,7 +580,7 @@ function getStore(config, router) {
         }
       },
       loaded(state, { url, data }) {
-        state.database[url] = processSTAC(state, data);
+        state.database[url] = data;
       },
       clear(state, url) {
         delete state.database[url];
@@ -657,10 +657,9 @@ function getStore(config, router) {
         if (!isObject(data) || !Array.isArray(data.features)) {
           return;
         }
-        let apiItems = data.features.map(feature => processSTAC(state, feature));
 
         if (show) {
-          state.apiItems = apiItems;
+          state.apiItems = data.features;
         }
 
         // Handle pagination links
@@ -680,7 +679,7 @@ function getStore(config, router) {
 
         if (stac instanceof STAC) {
           // ToDo: Prev link only required when state.apiItems is not cached(?) -> cache apiItems?
-          updateApiChildrenState(state, stac, apiItems, pages.next, pages.prev);
+          updateApiChildrenState(state, stac, data.features, pages.next, pages.prev);
         }
       },
       addApiCollections(state, { data, stac, show, searching = false }) {
@@ -689,14 +688,13 @@ function getStore(config, router) {
         }
 
         // todo: Convert to stac-js
-        let collections = data.collections.map(collection => processSTAC(state, collection));
         let nextLink = Utils.getLinkWithRel(data.links, 'next');
         if (show) {
           state.nextCollectionsLink = nextLink;
-          state.apiCollections = state.apiCollections.concat(collections);
+          state.apiCollections = state.apiCollections.concat(data.collections);
         }
         if (stac instanceof STAC && !searching) {
-          updateApiChildrenState(state, stac, collections, nextLink);
+          updateApiChildrenState(state, stac, data.collections, nextLink);
         }
       },
       resetApiCollections(state) {
@@ -855,7 +853,7 @@ function getStore(config, router) {
             if (!isObject(response.data)) {
               throw new BrowserError(i18n.global.t('errors.invalidJsonObject'));
             }
-            data = createSTAC(response.data, url);
+            data = createSTAC(response.data, url, cx);
             if (!(data instanceof STAC)) {
               // Might be a request to the /collections or .../items endpoints,
               // which returns an APICollection, not a STAC object.
@@ -1020,8 +1018,8 @@ function getStore(config, router) {
                   return data;
                 }
                 else {
-                  data = createSTAC(item, url);
-                  cx.commit('loaded', { data, url });
+                  data = createSTAC(item, url, cx);
+                  cx.commit('loaded', { url, data });
                   return data;
                 }
               } catch (error) {
@@ -1128,8 +1126,8 @@ function getStore(config, router) {
                 return data;
               }
               else {
-                data = createSTAC(collection, url);
-                cx.commit('loaded', { data, url });
+                data = createSTAC(collection, url, cx);
+                cx.commit('loaded', { url, data });
                 return data;
               }
             });

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -6,7 +6,7 @@ import urijs from 'urijs';
 import i18n, { loadMessages, detectDataLanguage, updateExternals } from '../i18n';
 import Utils, { BrowserError } from '../utils';
 import { toAbsolute } from 'stac-js/src/http.js';
-import { addMissingChildren, getDisplayTitle, createSTAC } from '../models/stac';
+import { addMissingChildren, getDisplayTitle, createSTAC, setApiData } from '../models/stac';
 import { CatalogLike, STAC } from 'stac-js';
 
 import auth from './auth.js';
@@ -277,11 +277,14 @@ function getStore(config, router) {
       toBrowserPath: (state, getters) => ref => {
         let url = ref;
         if (isObject(ref)) {
-          if (typeof ref.getAbsoluteUrl === 'function') {
+          if (typeof ref.getAbsoluteUrl === 'function') { // stac-js object
             url = ref.getAbsoluteUrl();
-          }
-          else {
+          } else if (typeof ref.toString === 'function') { // urijs object
+            url = ref.toString();
+          } else if (ref.href) { // plain STAC Link object
             url = ref.href;
+          }	else {
+            throw new Error('Invalid reference provided to toBrowserPath. Must be a stac-js object, URI object or string URL.');
           }
         }
         if (!hasText(url)) {
@@ -626,7 +629,7 @@ function getStore(config, router) {
 
         if (stac instanceof STAC) {
           // ToDo: Prev link only required when state.apiItems is not cached(?) -> cache apiItems?
-          stac.setApiData(apiItems, pages.next, pages.prev);
+          setApiData(stac, apiItems, pages.next, pages.prev);
         }
       },
       addApiCollections(state, { data, stac, show, searching = false }) {
@@ -642,7 +645,7 @@ function getStore(config, router) {
           state.apiCollections = state.apiCollections.concat(collections);
         }
         if (stac instanceof STAC && !searching) {
-          stac.setApiData(collections, nextLink);
+          setApiData(stac, collections, nextLink);
         }
       },
       resetApiCollections(state) {
@@ -966,7 +969,7 @@ function getStore(config, router) {
                   return data;
                 }
                 else {
-                  data = createSTAC(item, url, true);
+                  data = createSTAC(item, url);
                   cx.commit('loaded', { data, url });
                   return data;
                 }
@@ -1074,7 +1077,7 @@ function getStore(config, router) {
                 return data;
               }
               else {
-                data = createSTAC(collection, url, true);
+                data = createSTAC(collection, url);
                 cx.commit('loaded', { data, url });
                 return data;
               }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -33,7 +33,6 @@ function getStore(config, router) {
     url: '',
     page: null, // Function that returns title and optionally description of the current page as object
     data: null,
-    apiChildren: {},
     loading: true,
     parents: null,
     globalError: null,
@@ -78,6 +77,7 @@ function getStore(config, router) {
     state: Object.assign({}, config, localDefaults(), catalogDefaults(), {
       // Global settings
       database: {}, // STAC object, Error object or Loading object or Promise (when loading)
+      apiChildren: {},
       downloads: {},
       allowSelectCatalog: !config.catalogUrl,
       globalRequestQueryParameters: config.requestQueryParameters,
@@ -584,6 +584,7 @@ function getStore(config, router) {
       },
       clear(state, url) {
         delete state.database[url];
+        delete state.apiChildren[url];
       },
       resetCatalog(state, clearAll) {
         Object.assign(state, catalogDefaults());
@@ -1130,7 +1131,7 @@ function getStore(config, router) {
                 cx.commit('loaded', { url, data });
                 return data;
               }
-            });
+            }).filter(Boolean);
             if (reset) {
               cx.commit('resetApiCollections');
             }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -7,7 +7,7 @@ import i18n, { loadMessages, detectDataLanguage, updateExternals } from '../i18n
 import Utils, { BrowserError } from '../utils';
 import { toAbsolute } from 'stac-js/src/http.js';
 import { addMissingChildren, getDisplayTitle, createSTAC } from '../models/stac';
-import { CatalogLike, STAC } from 'stac-js';
+import { STAC } from 'stac-js';
 
 import auth from './auth.js';
 import { addQueryIfNotExists, hasAuthority, isAuthenticationError, Loading, stacRequest, stacRequestOptions } from './utils';
@@ -15,16 +15,81 @@ import { getBest } from 'stac-js/src/locales';
 import { TYPES } from "../components/ApiCapabilitiesMixin";
 import BrowserStorage from "../browser-store.js";
 
-function updateApiChildrenState(state, stac, list, next = false, prev = false) {
-  if (!(stac instanceof STAC) || !stac.isCatalogLike) {
+// type is either 'collections' or 'items', depending on which endpoint the list was loaded from
+function updateApiChildrenState(state, stac, type, list, next = false, prev = false) {
+  if (!stac?.isCatalogLike) {
     return;
   }
   const key = stac.getAbsoluteUrl();
   state.apiChildren[key] = {
+    type,
     list: Array.isArray(list) ? list : [],
     prev: prev || false,
     next: next || false
   };
+}
+
+// Returns the Loading object if a page of children is currently
+// being loaded for the given entity, otherwise null.
+function getApiChildrenLoading(state, stac) {
+  if (!stac?.isCatalogLike) {
+    return null;
+  }
+  const children = state.apiChildren[stac.getAbsoluteUrl()];
+  if (children instanceof Loading) {
+    return children;
+  }
+  return children?.loading instanceof Loading ? children.loading : null;
+}
+
+// Combines a list of children received from the API with the children linked to
+// from the STAC entity, depending on the given priority (see apiCatalogPriority).
+// Optionally includes the item links of the entity and pagination links for the API list.
+function combineChildren(stac, apiList, priority, { items = [], prev = false, next = false } = {}) {
+  const showCollections = !priority || priority === 'collections';
+  const showChilds = !priority || priority === 'childs';
+  let children = [];
+  if (showCollections && apiList.length > 0) {
+    children = apiList.slice(0);
+  }
+  if (showChilds) {
+    children = addMissingChildren(children, stac).concat(items);
+  }
+  if (showCollections && prev) {
+    children = [prev].concat(children);
+  }
+  if (showCollections && next) {
+    children.push(next);
+  }
+  return children;
+}
+
+// Fallback for APIs without proper links: If we detect OGC API like paths
+// (i.e. `collections/xyz` or `collections/xyz/items/abc`), go up the number of
+// levels configured for the detected endpoint to guess the URL of a parent entity.
+// Returns the guessed URL as string, or null.
+function guessParentUrlFromApiPath(url, levels) {
+  const uri = URI(url);
+  const path = uri.segment(-2);
+  const count = levels[path];
+  if (!count) {
+    return null;
+  }
+  for (let i = 0; i < count * 2; i++) {
+    uri.segment(-1, "");
+  }
+  return uri.toString();
+}
+
+// Returns the STAC object for the given URL from the cache,
+// otherwise creates it from the given data and adds it to the cache.
+function getOrCreateStac(cx, data, url) {
+  let stac = cx.getters.getStac(url);
+  if (!stac) {
+    stac = createSTAC(data, url, cx);
+    cx.commit('loaded', { url, data: stac });
+  }
+  return stac;
 }
 
 function getStore(config, router) {
@@ -59,7 +124,6 @@ function getStore(config, router) {
   const catalogDefaults = () => ({
     queue: [],
     privateQueryParameters: {},
-    authActions: [],
     conformsTo: [],
     dataLanguage: null,
 
@@ -77,6 +141,8 @@ function getStore(config, router) {
     state: Object.assign({}, config, localDefaults(), catalogDefaults(), {
       // Global settings
       database: {}, // STAC object, Error object or Loading object or Promise (when loading)
+      // Loading object (when loading the first page) or an object with the props
+      // type, list, prev, next and optionally loading (a Loading object when loading another page)
       apiChildren: {},
       downloads: {},
       allowSelectCatalog: !config.catalogUrl,
@@ -127,7 +193,7 @@ function getStore(config, router) {
         else if (typeof data === 'string') {
           id = data;
         }
-        return state.apiItemsLoading[id] || false;
+        return state.apiItemsLoading[id] instanceof Loading;
       },
       error: state => state.database[state.url] instanceof Error ? state.database[state.url] : null,
       getStac: state => (source, returnErrorObject = false) => {
@@ -169,17 +235,9 @@ function getStore(config, router) {
           return Utils.createLink(state.url, 'root', getDisplayTitle(state.data, state.catalogTitle));
         }
         else if (state.url) {
-          // Fallback: If we detect OGC API like paths, try to guess the paths
-          const uri = URI(state.url);
-          const path = uri.segment(-2);
-          if (['collections', 'items'].includes(path)) {
-            uri.segment(-1, "");
-            uri.segment(-1, "");
-            if (path === 'items') {
-              uri.segment(-1, "");
-              uri.segment(-1, "");
-            }
-            return Utils.createLink(uri.toString(), 'root', state.catalogTitle);
+          const rootUrl = guessParentUrlFromApiPath(state.url, { collections: 1, items: 2 });
+          if (rootUrl) {
+            return Utils.createLink(rootUrl, 'root', state.catalogTitle);
           }
         }
         return null;
@@ -192,14 +250,10 @@ function getStore(config, router) {
           }
         }
 
-        // Fallback: If we detect OGC API like paths, try to guess the paths
         if (state.url) {
-          let uri = URI(state.url);
-          let path = uri.segment(-2);
-          if (['collections', 'items'].includes(path)) {
-            uri.segment(-1, "");
-            uri.segment(-1, "");
-            return Utils.createLink(uri.toString(), 'parent');
+          const parentUrl = guessParentUrlFromApiPath(state.url, { collections: 1, items: 1 });
+          if (parentUrl) {
+            return Utils.createLink(parentUrl, 'parent');
           }
         }
 
@@ -207,20 +261,16 @@ function getStore(config, router) {
       },
       collectionLink: state => {
         if (state.data instanceof STAC) {
-          let link = state.data?.getStacLinkWithRel('collection');
+          let link = state.data.getStacLinkWithRel('collection');
           if (link) {
             return link;
           }
         }
 
-        // Fallback: If we detect OGC API like paths, try to guess the paths
         if (state.url) {
-          let uri = URI(state.url);
-          let path = uri.segment(-2);
-          if (path === 'items') {
-            uri.segment(-1, "");
-            uri.segment(-1, "");
-            return Utils.createLink(uri.toString(), 'collection');
+          const collectionUrl = guessParentUrlFromApiPath(state.url, { items: 1 });
+          if (collectionUrl) {
+            return Utils.createLink(collectionUrl, 'collection');
           }
         }
 
@@ -273,53 +323,40 @@ function getStore(config, router) {
         return [];
       },
       catalogs: state => {
-        let hasCollections = Boolean(state.data instanceof CatalogLike && state.data.getApiCollectionsLink() && state.apiCollections.length > 0);
-        let hasChilds = Boolean(state.data instanceof CatalogLike);
-        let showCollections = !state.apiCatalogPriority || state.apiCatalogPriority === 'collections';
-        let showChilds = !state.apiCatalogPriority || state.apiCatalogPriority === 'childs';
-        let catalogs = [];
-        if (hasCollections && showCollections) {
-          catalogs = catalogs.concat(state.apiCollections);
+        if (!state.data?.isCatalogLike) {
+          return [];
         }
-        if (hasChilds && showChilds) {
-          catalogs = addMissingChildren(catalogs, state.data);
-        }
-        return catalogs;
+        // Only include API collections if the entity actually exposes a collections endpoint,
+        // otherwise the list may contain stale data from a previously shown entity.
+        const hasCollections = Boolean(state.data.getApiCollectionsLink() && state.apiCollections.length > 0);
+        return combineChildren(state.data, hasCollections ? state.apiCollections : [], state.apiCatalogPriority);
       },
-      getApiChildrenState: state => stac => {
-        if (!(stac instanceof STAC) || !stac.isCatalogLike) {
+      isApiChildrenLoading: state => stac => Boolean(getApiChildrenLoading(state, stac)),
+      getApiChildren: state => stac => {
+        if (!stac?.isCatalogLike) {
           return null;
         }
         return state.apiChildren[stac.getAbsoluteUrl()] || {
+          type: null,
           list: [],
           prev: false,
           next: false
         };
       },
       getChildren: (state, getters) => (stac, priority = null) => {
-        if (!(stac instanceof STAC) || !stac.isCatalogLike) {
+        let apiChildren = getters.getApiChildren(stac);
+        if (!apiChildren) {
           return [];
         }
-
-        const apiChildren = getters.getApiChildrenState(stac);
-        const showCollections = !priority || priority === 'collections';
-        const showChilds = !priority || priority === 'childs';
-
-        let catalogEntries = [];
-        if (showCollections && apiChildren.list.length > 0) {
-          catalogEntries = apiChildren.list.slice(0);
+        if (apiChildren instanceof Loading) {
+          // The first page of children is still being loaded
+          apiChildren = { list: [], prev: false, next: false };
         }
-        let children = catalogEntries;
-        if (showChilds) {
-          children = addMissingChildren(catalogEntries, stac).concat(stac.getLinksWithRels(['item']));
-        }
-        if (showCollections && apiChildren.prev) {
-          children = [apiChildren.prev].concat(children);
-        }
-        if (showCollections && apiChildren.next) {
-          children.push(apiChildren.next);
-        }
-        return children;
+        return combineChildren(stac, apiChildren.list, priority, {
+          items: stac.getLinksWithRels(['item']),
+          prev: apiChildren.prev,
+          next: apiChildren.next
+        });
       },
 
       toBrowserPath: (state, getters) => ref => {
@@ -527,17 +564,6 @@ function getStore(config, router) {
           state.requestHeaders[key] = value;
         }
       },
-      requestAuth(state, callback) {
-        if (typeof callback === 'function') {
-          state.doAuth.push(callback);
-        }
-        else {
-          state.doAuth = [];
-        }
-      },
-      setAuthData(state, value) {
-        state.authData = value;
-      },
       state(state, newState) {
         state.stateQueryParameters = newState;
       },
@@ -596,6 +622,7 @@ function getStore(config, router) {
           state.catalogUrl = config.catalogUrl;
           state.catalogTitle = config.catalogTitle;
           state.database = {};
+          state.apiChildren = {};
         }
       },
       resetPage(state) {
@@ -643,16 +670,37 @@ function getStore(config, router) {
       setApiItemsLink(state, link) {
         state.apiItemsLink = link;
       },
-      toggleApiItemsLoading(state, collectionId = '') {
-        if (state.apiItemsLoading[collectionId]) {
-          delete state.apiItemsLoading[collectionId];
+      // Assigns the Loading object for the entity to the apiChildren directly
+      // (like in the database), or to the `loading` property if a list of
+      // children is already available. Removes it again if loading is not set.
+      loadingApiChildren(state, { stac, loading = null }) {
+        if (!stac?.isCatalogLike) {
+          return;
         }
-        else {
-          state.apiItemsLoading[collectionId] = true;
+        const url = stac.getAbsoluteUrl();
+        const children = state.apiChildren[url];
+        if (loading instanceof Loading) {
+          if (isObject(children) && !(children instanceof Loading)) {
+            children.loading = loading;
+          }
+          else {
+            state.apiChildren[url] = loading;
+          }
+        }
+        else if (children instanceof Loading) {
+          delete state.apiChildren[url];
+        }
+        else if (isObject(children)) {
+          delete children.loading;
         }
       },
-      setApiChildrenData(state, { stac, list, next = null, prev = null }) {
-        updateApiChildrenState(state, stac, list, next, prev);
+      loadingApiItems(state, { id = '', loading = null }) {
+        if (loading instanceof Loading) {
+          state.apiItemsLoading[id] = loading;
+        }
+        else {
+          delete state.apiItemsLoading[id];
+        }
       },
       setApiItems(state, { data, stac, show }) {
         if (!isObject(data) || !Array.isArray(data.features)) {
@@ -680,10 +728,10 @@ function getStore(config, router) {
 
         if (stac instanceof STAC) {
           // ToDo: Prev link only required when state.apiItems is not cached(?) -> cache apiItems?
-          updateApiChildrenState(state, stac, data.features, pages.next, pages.prev);
+          updateApiChildrenState(state, stac, 'items', data.features, pages.next, pages.prev);
         }
       },
-      addApiCollections(state, { data, stac, show, searching = false }) {
+      addApiCollections(state, { data, stac, show, searching = false, append = false }) {
         if (!isObject(data) || !Array.isArray(data.collections)) {
           return;
         }
@@ -694,14 +742,23 @@ function getStore(config, router) {
           state.nextCollectionsLink = nextLink;
           state.apiCollections = state.apiCollections.concat(data.collections);
         }
-        if (stac instanceof STAC && !searching) {
-          updateApiChildrenState(state, stac, data.collections, nextLink);
+        if (stac?.isSTAC && !searching) {
+          // Accumulate the loaded pages so that all consumers (e.g. the tree)
+          // see all collections that have been loaded so far.
+          let list = data.collections;
+          if (append) {
+            const existing = state.apiChildren[stac.getAbsoluteUrl()];
+            if (existing?.type === 'collections') {
+              list = existing.list.concat(list);
+            }
+          }
+          updateApiChildrenState(state, stac, 'collections', list, nextLink);
         }
       },
-      resetApiCollections(state) {
-        state.apiCollections = [];
+      resetApiCollections(state, { list = [], next = null } = {}) {
+        state.apiCollections = list;
         state.apiItemsLoading = {};
-        state.nextCollectionsLink = null;
+        state.nextCollectionsLink = next || null;
       },
       setCurrentApiCollectionsSearchId(state, searchId) {
         state.currentApiCollectionsSearchId = searchId;
@@ -812,20 +869,33 @@ function getStore(config, router) {
         }
         cx.commit('parents', parents);
       },
-      async tryLogin(cx, { url, action }) {
-        cx.commit('clear', url);
-        cx.commit('errored', { url, error: new BrowserError(i18n.global.t('authentication.unauthorized')) });
-        if (action) {
-          cx.commit('auth/addAction', action);
+      // Executes a request for the given STAC link (or URL) and returns the response.
+      // This is the single place that handles authentication errors for requests:
+      // If the request fails with an authentication error, asks the user to log in
+      // and settles with the result of the retried request after the login.
+      // If the user aborts the login or logs out, fails with the original error.
+      async request(cx, args) {
+        const { link, axiosOptions, noRetry } = (isObject(args) && args.link) ? args : { link: args };
+        try {
+          return await stacRequest(cx, link, axiosOptions);
+        } catch (error) {
+          if (noRetry || !cx.state.authConfig || cx.getters['auth/isLoggedIn'] || !isAuthenticationError(error)) {
+            throw error;
+          }
+          return await new Promise((resolve, reject) => {
+            cx.commit('auth/addAction', {
+              run: () => cx.dispatch('request', { link, axiosOptions, noRetry: true }).then(resolve, reject),
+              cancel: () => reject(error)
+            });
+            cx.dispatch('auth/requestLogin').catch(reject);
+          });
         }
-        await cx.dispatch('auth/requestLogin');
       },
       async load(cx, args) {
         let {
           url, // URL to load
           show, // Show the page when loading is finished, otherwise it's likely loaded in the background for completing specific parts of the page
           force, // Force reloading the data, omit the cache
-          noRetry, // Don't retry on authentication errors
           omitApi, // Don't load API collections or API items yet
           isRoot // Is a request for the root catalog initiated by this function, avoiding endless loops in some mis-configured instances (see https://github.com/radiantearth/stac-browser/issues/580)
         } = args;
@@ -850,7 +920,7 @@ function getStore(config, router) {
         if (!hasData) {
           cx.commit('loading', { url, loading });
           try {
-            const response = await stacRequest(cx, url);
+            const response = await cx.dispatch('request', { link: url });
             if (!isObject(response.data)) {
               throw new BrowserError(i18n.global.t('errors.invalidJsonObject'));
             }
@@ -880,13 +950,6 @@ function getStore(config, router) {
               await cx.dispatch('loadOgcApiConformance', conformanceLink);
             }
           } catch (error) {
-            if (!noRetry && cx.state.authConfig && isAuthenticationError(error)) {
-              await cx.dispatch('tryLogin', {
-                url,
-                action: () => cx.dispatch('load', Object.assign({ noRetry: true, force: true, show: true }, args))
-              });
-              return;
-            }
             console.error(error);
             cx.commit('errored', { url, error });
             return;
@@ -894,8 +957,8 @@ function getStore(config, router) {
         }
 
         // Load API Collections
-        const apiCollectionLink = data instanceof CatalogLike && data.getApiCollectionsLink();
-        const apiItemLink = data instanceof CatalogLike && data.getApiItemsLink();
+        const apiCollectionLink = data.isCatalogLike && data.getApiCollectionsLink();
+        const apiItemLink = data.isCatalogLike && data.getApiItemsLink();
         if (!omitApi && apiCollectionLink) {
           let loadArgs = { stac: data, show: loading.show };
           try {
@@ -949,10 +1012,9 @@ function getStore(config, router) {
         }
       },
       async loadApiItems(cx, args) {
-        let { link, stac, show, filters, noRetry } = args;
+        let { link, stac, show, filters } = args;
         let collectionId = stac instanceof STAC ? stac.id : '';
-        cx.commit('toggleApiItemsLoading', collectionId);
-
+        cx.commit('loadingApiItems', { id: collectionId, loading: new Loading(show) });
         try {
           let baseUrl = cx.state.url;
           if (stac instanceof STAC) {
@@ -969,7 +1031,7 @@ function getStore(config, router) {
           }
           link = Utils.addFiltersToLink(link, filters, cx.state.itemsPerPage, sort);
 
-          let response = await stacRequest(cx, link);
+          let response = await cx.dispatch('request', { link });
           if (!isObject(response.data) || !Array.isArray(response.data.features)) {
             throw new BrowserError(i18n.global.t('errors.invalidStacItems'));
           }
@@ -1013,16 +1075,7 @@ function getStore(config, router) {
                 else {
                   return null;
                 }
-                url = url.toString();
-                let data = cx.getters.getStac(url);
-                if (data) {
-                  return data;
-                }
-                else {
-                  data = createSTAC(item, url, cx);
-                  cx.commit('loaded', { url, data });
-                  return data;
-                }
+                return getOrCreateStac(cx, item, url.toString());
               } catch (error) {
                 console.error(error);
                 return null;
@@ -1032,26 +1085,18 @@ function getStore(config, router) {
               cx.commit('setApiItemsLink', link);
             }
             cx.commit('setApiItems', { data: response.data, stac, show });
-            cx.commit('toggleApiItemsLoading', collectionId);
             return response;
           }
-        } catch (error) {
-          cx.commit('toggleApiItemsLoading', collectionId);
-          if (!noRetry && cx.state.authConfig && isAuthenticationError(error)) {
-            await cx.dispatch('tryLogin', {
-              url: link.href,
-              action: () => cx.dispatch('loadApiItems', Object.assign({ noRetry: true, force: true }, args))
-            });
-            return;
-          }
-          throw error;
+        } finally {
+          cx.commit('loadingApiItems', { id: collectionId });
         }
       },
       async loadNextApiCollections(cx, args) {
-        let { stac, show, noRetry, q, searching = false, searchRequestId } = args;
+        let { stac, show, q, searching = false, searchRequestId, next = false } = args;
         let link;
         let reset = false;
-        if (stac) { // First page
+        const firstPage = Boolean(stac) && !next;
+        if (firstPage) {
           if (show) {
             // Track request IDs for both searching and non-searching reloads
             // so stale responses can be discarded consistently.
@@ -1060,16 +1105,27 @@ function getStore(config, router) {
               searchRequestId = Date.now();
             }
             cx.commit('setCurrentApiCollectionsSearchId', searchRequestId);
-            // If we load from new collections, reset list of collections.
-            // Otherwise we may append to collections from a parent entity.
-            // https://github.com/radiantearth/stac-browser/issues/617
-            if (searching) {
-              // When searching, only reset after the request to ensure the previous list remains visible if the request fails.
-              reset = true;
-            } else {
-              // For non-searching requests, reset immediately to avoid showing collections from a previous request.
+          }
+          if (!searching) {
+            // Reuse the collections that have already been loaded for this entity
+            // instead of fetching (and starting over from) the first page again.
+            const cached = cx.state.apiChildren[stac.getAbsoluteUrl()];
+            if (cached?.type === 'collections') {
+              if (show) {
+                cx.commit('resetApiCollections', cached);
+              }
+              return;
+            }
+            if (show) {
+              // If we load from new collections, reset list of collections.
+              // Otherwise we may append to collections from a parent entity.
+              // https://github.com/radiantearth/stac-browser/issues/617
               cx.commit('resetApiCollections');
             }
+          }
+          else if (show) {
+            // When searching, only reset after the request to ensure the previous list remains visible if the request fails.
+            reset = true;
           }
           link = stac.getLinkWithRel('data');
           let sort = null;
@@ -1082,15 +1138,38 @@ function getStore(config, router) {
           }
           link = Utils.addFiltersToLink(link, filters, cx.state.collectionsPerPage, sort);
         }
-        else { // Second page and after
+        else if (next && !searching && stac?.isCatalogLike) {
+          // Load the next page of collections for the given entity (e.g. from the tree)
+          const cached = cx.state.apiChildren[stac.getAbsoluteUrl()];
+          if (cached?.type !== 'collections') {
+            return;
+          }
+          link = cached.next;
+          // Keep the currently shown collection list in sync if it shows the same list
+          show = show || cx.state.nextCollectionsLink === link;
+        }
+        else { // Second page and after for the currently shown collection list
           stac = cx.state.data;
           link = cx.state.nextCollectionsLink;
         }
         if (!link) {
           return;
         }
+        // Assign a Loading object to the apiChildren while loading so that the same
+        // page is not requested multiple times in parallel, e.g. by the tree and the
+        // collection list auto-loading the next page simultaneously.
+        // Requests for search results are not tracked, they don't belong to the children.
+        const track = !searching && stac?.isCatalogLike;
+        if (track) {
+          const pending = getApiChildrenLoading(cx.state, stac);
+          if (pending && (pending.show || !show)) {
+            // The pending request covers everything this request would do
+            return;
+          }
+          cx.commit('loadingApiChildren', { stac, loading: new Loading(show) });
+        }
         try {
-          let response = await stacRequest(cx, link);
+          let response = await cx.dispatch('request', { link });
           // Check if this response is still relevant (not superseded by a newer search request)
           if (searchRequestId !== undefined && searchRequestId !== cx.state.currentApiCollectionsSearchId) {
             // Discard results from stale search requests
@@ -1121,60 +1200,29 @@ function getStore(config, router) {
               if (!url) {
                 return null; // We can't detect a URL, skip this flawed collection
               }
-              url = url.toString();
-              let data = cx.getters.getStac(url);
-              if (data) {
-                return data;
-              }
-              else {
-                data = createSTAC(collection, url, cx);
-                cx.commit('loaded', { url, data });
-                return data;
-              }
+              return getOrCreateStac(cx, collection, url.toString());
             }).filter(Boolean);
             if (reset) {
               cx.commit('resetApiCollections');
             }
             cx.commit('addApiCollections', {
-              data: response.data, stac, show, searching
+              data: response.data, stac, show, searching, append: !firstPage
             });
           }
-        } catch (error) {
-          if (!noRetry && cx.state.authConfig && isAuthenticationError(error)) {
-            await cx.dispatch('tryLogin', {
-              url: link.href,
-              action: () => cx.dispatch('loadNextApiCollections', Object.assign({ noRetry: true, force: true }, args))
-            });
-            return;
+        } finally {
+          if (track) {
+            cx.commit('loadingApiChildren', { stac });
           }
-          throw error;
         }
       },
       async loadOgcApiConformance(cx, link) {
-        let response = await stacRequest(cx, link);
+        let response = await cx.dispatch('request', { link });
         if (isObject(response.data) && Array.isArray(response.data.conformsTo)) {
           cx.commit('setConformanceClasses', response.data.conformsTo);
         }
       },
-      // eslint-disable-next-line require-await
-      async retryAfterAuth(cx) {
-        let errorFn = error => cx.commit('showGlobalError', {
-          error,
-          message: i18n.global.t('errors.authFailed')
-        });
-
-        for (let callback of cx.state.doAuth) {
-          try {
-            let p = callback();
-            if (p instanceof Promise) {
-              p.catch(errorFn);
-            }
-          } catch (error) {
-            errorFn(error);
-          }
-        }
-      },
-      async altDownload(cx, link) {
+      async altDownload(cx, args) {
+        const { link, noRetry } = (isObject(args) && args.link) ? args : { link: args };
         const options = stacRequestOptions(cx, link);
         try {
           // Enable the loading indicator
@@ -1198,6 +1246,12 @@ function getStore(config, router) {
           const res = await fetch(url, axiosOptions);
           // todo: use getErrorMessage / getErrorCode instead?
           if (res.status >= 400) {
+            if ([401, 403].includes(res.status) && !noRetry && cx.state.authConfig && !cx.getters['auth/isLoggedIn']) {
+              // Ask the user to log in and restart the download afterwards
+              cx.commit('auth/addAction', () => cx.dispatch('altDownload', { link, noRetry: true }));
+              await cx.dispatch('auth/requestLogin');
+              return;
+            }
             let msg;
             switch (res.status) {
               case 401:

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -242,10 +242,10 @@ function getStore(config, router) {
           searchLink = state.data.getSearchLink();
         }
         if (searchLink) {
-          return `/search${state.data.getBrowserPath()}`;
+          return `/search${getters.toBrowserPath(state.data)}`;
         }
         else if (getters.root && state.allowSelectCatalog) {
-          return `/search${getters.root.getBrowserPath()}`;
+          return `/search${getters.toBrowserPath(getters.root)}`;
         }
         return '/search';
       },
@@ -274,7 +274,16 @@ function getStore(config, router) {
         return catalogs;
       },
 
-      toBrowserPath: (state, getters) => url => {
+      toBrowserPath: (state, getters) => ref => {
+        let url = ref;
+        if (isObject(ref)) {
+          if (typeof ref.getAbsoluteUrl === 'function') {
+            url = ref.getAbsoluteUrl();
+          }
+          else {
+            url = ref.href;
+          }
+        }
         if (!hasText(url)) {
           url = '/';
         }
@@ -768,7 +777,6 @@ function getStore(config, router) {
           isRoot // Is a request for the root catalog initiated by this function, avoiding endless loops in some mis-configured instances (see https://github.com/radiantearth/stac-browser/issues/580)
         } = args;
 
-        const path = cx.getters.toBrowserPath(url);
         url = toAbsolute(url, cx.state.url);
 
         // Make sure we have all authentication details
@@ -793,7 +801,7 @@ function getStore(config, router) {
             if (!isObject(response.data)) {
               throw new BrowserError(i18n.global.t('errors.invalidJsonObject'));
             }
-            data = createSTAC(response.data, url, path);
+            data = createSTAC(response.data, url);
             if (!(data instanceof STAC)) {
               // Might be a request to the /collections or .../items endpoints,
               // which returns an APICollection, not a STAC object.
@@ -805,7 +813,7 @@ function getStore(config, router) {
               // If we prefer another language abort redirect to the new language
               let localeLink = data.getLocaleLink(cx.state.dataLanguage);
               if (localeLink) {
-                router.replace(cx.getters.toBrowserPath(localeLink.href));
+                router.replace(cx.getters.toBrowserPath(localeLink));
                 return;
               }
             }
@@ -958,8 +966,7 @@ function getStore(config, router) {
                   return data;
                 }
                 else {
-                  let itemPath = cx.getters.toBrowserPath(url);
-                  data = createSTAC(item, url, itemPath);
+                  data = createSTAC(item, url);
                   data._incomplete = true;
                   cx.commit('loaded', { data, url });
                   return data;
@@ -1068,8 +1075,7 @@ function getStore(config, router) {
                 return data;
               }
               else {
-                let collectionPath = cx.getters.toBrowserPath(url);
-                data = createSTAC(collection, url, collectionPath);
+                data = createSTAC(collection, url);
                 data._incomplete = true;
                 cx.commit('loaded', { data, url });
                 return data;

--- a/src/store/utils.js
+++ b/src/store/utils.js
@@ -1,5 +1,4 @@
 import axios from "axios";
-import { markRaw } from 'vue';
 import { hasText, isObject, size } from 'stac-js/src/utils.js';
 import i18n from '../i18n';
 
@@ -55,13 +54,6 @@ export async function stacRequest(cx, link, axiosOptions = {}) {
   const options = stacRequestOptions(cx, link);
   // Execute the request
   return await axios(Object.assign(options, axiosOptions));
-}
-
-export function processSTAC(state, stac) {
-  if (typeof state.preprocessSTAC === 'function') {
-    stac = state.preprocessSTAC(stac, state);
-  }
-  return markRaw(stac);
 }
 
 export function isAuthenticationError(error) {

--- a/src/views/ApiSearch.vue
+++ b/src/views/ApiSearch.vue
@@ -81,7 +81,7 @@ import ErrorAlert from '../components/ErrorAlert.vue';
 import { getDisplayTitle, createSTAC } from '../models/stac';
 import { STAC } from 'stac-js';
 import { defineComponent, defineAsyncComponent } from 'vue';
-import { getErrorCode, getErrorMessage, processSTAC, stacRequest } from '../store/utils';
+import { getErrorCode, getErrorMessage, stacRequest } from '../store/utils';
 import { mapGetters, mapState } from "vuex";
 import { BTab, BTabs } from 'bootstrap-vue-next';
 
@@ -269,8 +269,7 @@ export default defineComponent({
         }
         else {
           const url = this.link.getAbsoluteUrl();
-          const data = createSTAC(response.data, url);
-          data[key] = data[key].map(stac => processSTAC(this.$store.state, stac));
+          const data = createSTAC(response.data, url, this.$store);
           this.data = data;
         }
       } catch (error) {

--- a/src/views/ApiSearch.vue
+++ b/src/views/ApiSearch.vue
@@ -34,8 +34,8 @@
         <b-alert v-else-if="results.length === 0" variant="warning" show>{{ $t('search.noItemsFound') }}</b-alert>
         <template v-else>
           <WidgetHook id="view-search-results-start" />
-          <div id="search-map" v-if="resultCollection">
-            <MapView :stac="parent" :children="resultCollection" onfocusOnly popover />
+          <div id="search-map" v-if="data">
+            <MapView :stac="parent" :children="data" onfocusOnly popover />
           </div>
           <Catalogs
             v-if="isCollectionSearch" :catalogs="results" collectionsOnly
@@ -74,12 +74,11 @@
 
 <script>
 import Utils from '../utils';
-import { toAbsolute } from 'stac-js/src/http.js';
 import { isObject, size } from 'stac-js/src/utils.js';
 import SearchFilter from '../components/SearchFilter.vue';
 import Loading from '../components/Loading.vue';
 import ErrorAlert from '../components/ErrorAlert.vue';
-import { getDisplayTitle, createSTAC, CollectionCollection, ItemCollection } from '../models/stac';
+import { getDisplayTitle, createSTAC } from '../models/stac';
 import { STAC } from 'stac-js';
 import { defineComponent, defineAsyncComponent } from 'vue';
 import { getErrorCode, getErrorMessage, processSTAC, stacRequest } from '../store/utils';
@@ -130,7 +129,7 @@ export default defineComponent({
       return size(this.selectedCollections);
     },
     totalCount() {
-      if (typeof this.data.numberMatched === 'number') {
+      if (typeof this.data?.numberMatched === 'number') {
         return this.data.numberMatched;
       }
       return null;
@@ -147,54 +146,11 @@ export default defineComponent({
     itemSearch() {
       return this.canSearchItems && this.parent && this.parent.getSearchLink();
     },
-    resultCollection() {
-      if (this.isCollectionSearch) {
-        return new CollectionCollection({
-          collections: this.results,
-          links: []
-        });
-      }
-      else {
-        return new ItemCollection({
-          type: 'FeatureCollection',
-          features: this.results,
-          links: []
-        });
-      }
-    },
     results() {
-      if (size(this.data) === 0) {
-        return [];
-      }
-      let list = this.isCollectionSearch ? this.data.collections : this.data.features;
-      let type = this.isCollectionSearch ? 'Collection' : 'Feature';
-      if (!Array.isArray(list)) {
-        return [];
-      }
-      // todo: use itemcollection class
-      return list
-        .map(obj => {
-          try {
-            if (!isObject(obj) || obj.type !== type) {
-              return null;
-            }
-            let selfLink = Utils.getLinkWithRel(obj.links, 'self');
-            let url;
-            if (selfLink?.href) {
-              url = toAbsolute(selfLink.href, this.link.href);
-            }
-            let stac = createSTAC(obj, url);
-            stac = processSTAC(this.$store.state, stac);
-            return stac;
-          } catch (error) {
-            console.error(error);
-            return null;
-          }
-        })
-        .filter(obj => obj instanceof STAC);
+      return this.data?.getAll() || [];
     },
     pagination() {
-      return Utils.getPaginationLinks(this.data);
+      return this.data?.getPaginationLinks() || {};
     },
     filters() {
       return this.isCollectionSearch ? this.collectionFilters : this.itemFilters;
@@ -297,21 +253,25 @@ export default defineComponent({
       this.error = null;
       this.errorId = null;
       this.loading = true;
-      try {
-        this.link = Utils.addFiltersToLink(link, this.filters, this.searchResultsPerPage);
 
-        const key = this.isCollectionSearch ? 'collections' : 'features';
+      this.link = Utils.addFiltersToLink(link, this.filters, this.searchResultsPerPage);
+
+      try {
         const response = await stacRequest(this.$store, this.link);
         if (response) {
           this.showPage(response.config.url);
         }
+
+        const key = this.isCollectionSearch ? 'collections' : 'features';
         if (!isObject(response.data) || !Array.isArray(response.data[key])) {
           this.data = {};
           this.error = this.$t(this.isCollectionSearch ? 'errors.invalidStacCollections' : 'errors.invalidStacItems');
         }
         else {
           const url = this.link.getAbsoluteUrl();
-          this.data = createSTAC(response.data, url);
+          const data = createSTAC(response.data, url);
+          data[key] = data[key].map(stac => processSTAC(this.$store.state, stac));
+          this.data = data;
         }
       } catch (error) {
         this.data = {};

--- a/src/views/ApiSearch.vue
+++ b/src/views/ApiSearch.vue
@@ -254,9 +254,9 @@ export default defineComponent({
       this.errorId = null;
       this.loading = true;
 
-      this.link = Utils.addFiltersToLink(link, this.filters, this.searchResultsPerPage);
-
       try {
+        this.link = Utils.addFiltersToLink(link, this.filters, this.searchResultsPerPage);
+      
         const response = await stacRequest(this.$store, this.link);
         if (response) {
           this.showPage(response.config.url);

--- a/src/views/ApiSearch.vue
+++ b/src/views/ApiSearch.vue
@@ -264,7 +264,7 @@ export default defineComponent({
 
         const key = this.isCollectionSearch ? 'collections' : 'features';
         if (!isObject(response.data) || !Array.isArray(response.data[key])) {
-          this.data = {};
+          this.data = null;
           this.error = this.$t(this.isCollectionSearch ? 'errors.invalidStacCollections' : 'errors.invalidStacItems');
         }
         else {
@@ -273,7 +273,7 @@ export default defineComponent({
           this.data = data;
         }
       } catch (error) {
-        this.data = {};
+        this.data = null;
         this.error = getErrorMessage(error);
         this.errorId = getErrorCode(error);
       } finally {

--- a/src/views/ApiSearch.vue
+++ b/src/views/ApiSearch.vue
@@ -81,7 +81,7 @@ import ErrorAlert from '../components/ErrorAlert.vue';
 import { getDisplayTitle, createSTAC } from '../models/stac';
 import { STAC } from 'stac-js';
 import { defineComponent, defineAsyncComponent } from 'vue';
-import { getErrorCode, getErrorMessage, stacRequest } from '../store/utils';
+import { getErrorCode, getErrorMessage } from '../store/utils';
 import { mapGetters, mapState } from "vuex";
 import { BTab, BTabs } from 'bootstrap-vue-next';
 
@@ -257,7 +257,7 @@ export default defineComponent({
       try {
         this.link = Utils.addFiltersToLink(link, this.filters, this.searchResultsPerPage);
       
-        const response = await stacRequest(this.$store, this.link);
+        const response = await this.$store.dispatch('request', { link: this.link });
         if (response) {
           this.showPage(response.config.url);
         }

--- a/src/views/ApiSearch.vue
+++ b/src/views/ApiSearch.vue
@@ -125,7 +125,7 @@ export default defineComponent({
   },
   computed: {
     ...mapState(['catalogUrl', 'catalogTitle', 'searchResultsPerPage', 'stateQueryParameters']),
-    ...mapGetters(['canSearchItems', 'canSearchCollections', 'getStac', 'root', 'collectionLink', 'parentLink', 'fromBrowserPath', 'toBrowserPath']),
+    ...mapGetters(['canSearchItems', 'canSearchCollections', 'getStac', 'root', 'collectionLink', 'parentLink', 'fromBrowserPath']),
     selectedCollectionCount() {
       return size(this.selectedCollections);
     },
@@ -183,7 +183,7 @@ export default defineComponent({
             if (selfLink?.href) {
               url = toAbsolute(selfLink.href, this.link.href);
             }
-            let stac = createSTAC(obj, url, this.toBrowserPath(url));
+            let stac = createSTAC(obj, url);
             stac = processSTAC(this.$store.state, stac);
             return stac;
           } catch (error) {
@@ -311,7 +311,7 @@ export default defineComponent({
         }
         else {
           const url = this.link.getAbsoluteUrl();
-          this.data = createSTAC(response.data, url, this.toBrowserPath(url));
+          this.data = createSTAC(response.data, url);
         }
       } catch (error) {
         this.data = {};

--- a/src/views/Catalog.vue
+++ b/src/views/Catalog.vue
@@ -48,7 +48,7 @@
         <Catalogs
           :apiSearch="hasApiCollections" :catalogs="catalogs" :hasMore="hasMore"
           @load-more="loadMoreCollections" @search="searchCollections"
-          :loading="Boolean(loadingCollections)" :loadingMore="loadingCollections === 'more'"
+          :loading="Boolean(loadingCollections) || loadingNextCollectionsPage" :loadingMore="loadingCollections === 'more' || loadingNextCollectionsPage"
         />
         <WidgetHook id="view-catalog-catalogs-end" />
       </b-col>
@@ -123,7 +123,7 @@ export default defineComponent({
   },
   computed: {
     ...mapState(['data', 'apiCatalogPriority', 'apiItemsLink', 'apiItemsPagination', 'apiItemsNumberMatched', 'nextCollectionsLink', 'stateQueryParameters']),
-    ...mapGetters(['catalogs', 'collectionLink', 'isCollection', 'items', 'getApiItemsLoading', 'parentLink', 'rootLink']),
+    ...mapGetters(['catalogs', 'collectionLink', 'isApiChildrenLoading', 'isCollection', 'items', 'getApiItemsLoading', 'parentLink', 'rootLink']),
     ignoredMetadataFields() {
       return getIgnoredFields(this.data, 'CatalogLike');
     },
@@ -152,6 +152,10 @@ export default defineComponent({
     },
     hasMore() {
       return this.apiCatalogPriority !== 'childs' && Boolean(this.nextCollectionsLink);
+    },
+    loadingNextCollectionsPage() {
+      // Pages may also be loading through other components, e.g. the tree
+      return this.isApiChildrenLoading(this.data);
     },
     licenses() {
       if (this.data.license) {

--- a/src/views/Catalog.vue
+++ b/src/views/Catalog.vue
@@ -82,7 +82,7 @@ import { formatLicense, formatTemporalExtents } from '@radiantearth/stac-fields/
 import Utils from '../utils';
 import { hasText, isObject, size } from 'stac-js/src/utils.js';
 import { addSchemaToDocument, createCatalogSchema } from '../schema-org';
-import { ItemCollection } from '../models/stac.js';
+import { ItemCollection } from 'stac-js';
 import DeprecationMixin from '../components/DeprecationMixin.js';
 import { BTab, BTabs, BCard } from 'bootstrap-vue-next';
 import { getIgnoredFields } from '../ignored-metadata.js';

--- a/tests/e2e/catalog.spec.js
+++ b/tests/e2e/catalog.spec.js
@@ -307,6 +307,48 @@ test.describe('Catalog - Children', () => {
     await expect(page.locator('.catalogs .card-grid > *')).toHaveCount(0);
   });
   
+  test('API - collection list is restored when returning to the page', async ({ page, worker }) => {
+    const { api } = createAPI();
+    const collection = api.addCollection('my-collection').setMetadata({ title: 'Test Collection' });
+    api.addItem(collection, 'my-item');
+
+    await api.createServer(worker);
+
+    await page.goto(api.root.getBrowserPath());
+    await waitForBrowserReady(page);
+    await expect(page.getByRole('link', { name: new RegExp(collection.getMetadata().title) })).toBeVisible();
+
+    // Visit the search page and return to the catalog page (in-app navigation,
+    // not full page loads), the collections should be restored from the cache
+    await page.getByRole('navigation').getByRole('button', { name: /search/i }).click();
+    await expect(page).toHaveURL(/\/search/);
+    await page.goBack();
+    await waitForBrowserReady(page);
+
+    await expect(page.getByRole('link', { name: new RegExp(collection.getMetadata().title) })).toBeVisible();
+  });
+
+  test('API - tree auto-loads more collection pages', async ({ page, worker }) => {
+    // One collection per page, so that the second collection is only
+    // available after loading the next page of the collections endpoint
+    const api = API.defaultApi({}, { defaultLimit: 1 });
+    const collection1 = api.addCollection('collection-1').setMetadata({ title: 'Test Collection 1' });
+    const collection2 = api.addCollection('collection-2').setMetadata({ title: 'Test Collection 2' });
+
+    await api.createServer(worker);
+
+    // Open a collection page so that only the tree can trigger loading more collection pages
+    await page.goto(collection1.getBrowserPath());
+    await waitForBrowserReady(page);
+
+    await page.getByRole('button', { name: /browse/i }).click();
+
+    const sidebar = page.locator('#sidebar');
+    await expect(sidebar.getByText(collection1.getMetadata().title)).toBeVisible();
+    // The next page of collections loads automatically once the tree is shown
+    await expect(sidebar.getByText(collection2.getMetadata().title)).toBeVisible();
+  });
+
   test('API - navigates into a child collection on click', async ({ page, worker }) => {
     const { api } = createAPI();
     const collection = api.addCollection('my-collection');

--- a/tests/fixtures/builders/collectionCollection.js
+++ b/tests/fixtures/builders/collectionCollection.js
@@ -46,13 +46,14 @@ export default class CollectionCollection extends APICollection {
     return this;
   }
   
-  build() {
+  build(searchParams = {}) {
     const data = super.build();
     for(let collection in data.collections){
       if(data.collections[collection] instanceof Collection){
         data.collections[collection] = data.collections[collection].build();
       }
     }
+    this.paginateData('collections', searchParams);
     return data;
   }
 }

--- a/tests/fixtures/instances/instance.js
+++ b/tests/fixtures/instances/instance.js
@@ -80,9 +80,9 @@ export default class Instance {
         if(method === 'GET'){
           handlers.push(http.get(url, ({request}) => {
             try { 
-              const url = new URL(request.url);
-              options.verbose && console.log(`GET ${url}`);
-              const params = Object.fromEntries(url.searchParams); //quick patch. breaks with multiple arguments of the same key
+              const parsedUrl = new URL(request.url);
+              options.verbose && console.log(`GET ${parsedUrl}`);
+              const params = Object.fromEntries(parsedUrl.searchParams); //quick patch. breaks with multiple arguments of the same key
               const obj = endpoint.build(params);
               return HttpResponse.json(obj);
             } catch (e) {


### PR DESCRIPTION
## Proposed Changes

Internal clean-up, but potentially breaking in preprocessSTAC.

## Checklist

- [x] Added [changelog entry](CHANGELOG.md)
- [x] Added translations for new or changed UI strings
- [x] Executed linter (`npm run lint`)
- [x] Added and executed tests (`npm test`)
