### PR TITLE
fix(docker): redirect bare pathPrefix to itself with trailing slash.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Redirect bare `pathPrefix` URLs to their trailing-slash form in the Docker/nginx image (e.g. `/browser` → `/browser/`)
 - Fix global error handling in certain edge-cases
 - Improve speed of catalog/collection duplicate detection
 - Fix search link detection

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ ADD docker/docker-entrypoint.sh /docker-entrypoint.d/40-stac-browser-entrypoint.
 
 RUN barePrefix=$(printf '%s' "${pathPrefix}" | sed 's|/*$||') && \
     if [ -n "${barePrefix}" ]; then \
-      sed -i "s|<prefixRedirect>|location = ${barePrefix} { return 301 ${barePrefix}/; }|" /etc/nginx/conf.d/default.conf; \
+    sed -i "s|<prefixRedirect>|location = ${barePrefix} { return 301 ${barePrefix}/\$is_args\$args; }|" /etc/nginx/conf.d/default.conf; \
     else \
       sed -i '/<prefixRedirect>/d' /etc/nginx/conf.d/default.conf; \
     fi && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ ADD docker/docker-entrypoint.sh /docker-entrypoint.d/40-stac-browser-entrypoint.
 
 RUN barePrefix=$(printf '%s' "${pathPrefix}" | sed 's|/*$||') && \
     if [ -n "${barePrefix}" ]; then \
-    sed -i "s|<prefixRedirect>|location = ${barePrefix} { return 301 ${barePrefix}/\$is_args\$args; }|" /etc/nginx/conf.d/default.conf; \
+      sed -i "s|<prefixRedirect>|location = ${barePrefix} { return 301 ${barePrefix}/\$is_args\$args; }|" /etc/nginx/conf.d/default.conf; \
     else \
       sed -i '/<prefixRedirect>/d' /etc/nginx/conf.d/default.conf; \
     fi && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,13 @@ COPY --from=build-step /app/dist /usr/share/nginx/html
 COPY --from=build-step /app/docker/default.conf /etc/nginx/conf.d/default.conf
 ADD docker/docker-entrypoint.sh /docker-entrypoint.d/40-stac-browser-entrypoint.sh
 
-RUN sed -i "s|<pathPrefix>|${pathPrefix}|" /etc/nginx/conf.d/default.conf && \
+RUN barePrefix=$(printf '%s' "${pathPrefix}" | sed 's|/*$||') && \
+    if [ -n "${barePrefix}" ]; then \
+      sed -i "s|<prefixRedirect>|location = ${barePrefix} { return 301 ${barePrefix}/; }|" /etc/nginx/conf.d/default.conf; \
+    else \
+      sed -i '/<prefixRedirect>/d' /etc/nginx/conf.d/default.conf; \
+    fi && \
+    sed -i "s|<pathPrefix>|${pathPrefix}|" /etc/nginx/conf.d/default.conf && \
     chown -R nginx:nginx /usr/share/nginx/html && \
     chmod +x /docker-entrypoint.d/40-stac-browser-entrypoint.sh
 

--- a/docker/default.conf
+++ b/docker/default.conf
@@ -1,7 +1,9 @@
 server {
     listen 8080;
     server_name  localhost;
+    absolute_redirect off;
 
+    <prefixRedirect>
     location <pathPrefix> {
         alias  /usr/share/nginx/html/;
         index  index.html;

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -89,7 +89,7 @@ So, essentially, in the end you get an nginx instance that serves static files.
 ## Essential parts
 
 1. [Dockerfile](../Dockerfile) - contains information on how to build the image.
-2. [docker/default.conf](../docker/default.conf) - nginx configuration template, where `<pathPrefix>` and an optional bare-prefix redirect are generated during build.
+2. [docker/default.conf](../docker/default.conf) - nginx configuration template. During build, `<pathPrefix>` is replaced and a bare-prefix redirect is added when `pathPrefix` is not `/`.
 3. [docker/docker-entrypoint.sh](../docker/docker-entrypoint.sh) - a start script to read the passed variables and produce the `runtime-config.js` file.
 
 ## FAQ

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -62,7 +62,8 @@ docker run -p 8080:8080 -e SB_catalogUrl="https://earth-search.aws.element84.com
 
 If you want to pass all the other arguments to `npm run build` directly, you can modify to the Dockerfile as needed.
 
-STAC browser is now available at `http://localhost:8080/browser`
+STAC Browser is now available at `http://localhost:8080/browser/`.
+Requests to `http://localhost:8080/browser` (no trailing slash) are redirected there.
 
 ## Use an existing image
 
@@ -88,7 +89,7 @@ So, essentially, in the end you get an nginx instance that serves static files.
 ## Essential parts
 
 1. [Dockerfile](../Dockerfile) - contains information on how to build the image.
-2. [docker/default.conf](../docker/default.conf) - nginx configuration template, where `<pathPrefix>` is replaced during build.
+2. [docker/default.conf](../docker/default.conf) - nginx configuration template, where `<pathPrefix>` and an optional bare-prefix redirect are generated during build.
 3. [docker/docker-entrypoint.sh](../docker/docker-entrypoint.sh) - a start script to read the passed variables and produce the `runtime-config.js` file.
 
 ## FAQ


### PR DESCRIPTION
## Proposed Changes

Redirect bare pathPrefix URLs to their trailing-slash form in the Docker/nginx image. Concretely:

When built with `pathPrefix=/browser/`, `GET /browser` now returns `301` with `Location: /browser/`. Root deployments (`pathPrefix=/`) remain unchanged.

**Changes:**

* Generate an exact-match nginx redirect from the build-time pathPrefix
* Set absolute_redirect off so redirects use relative Location headers (works behind port mapping and reverse proxies)
* Updated docs

## Checklist

- [x] Added [changelog entry](CHANGELOG.md)
- ~~[ ] Added translations for new or changed UI strings~~
- [x] Executed linter (`npm run lint`)
- ~~[ ] Added and executed tests (`npm test`)~~
