### PR TITLE
Consider alternate assets when detecting thumbnails #910

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Alternate assets are considered as thumbnail and preview candidates if the original asset can't be shown in a browser
 - Redirect bare `pathPrefix` URLs to their trailing-slash form in the Docker/nginx image (e.g. `/browser` → `/browser/`)
 - Geometries that cross the antimeridian are split into multi-geometries so that footprints render correctly on the map
 - Fix global error handling in certain edge-cases

--- a/src/components/ShowAssetLinkMixin.js
+++ b/src/components/ShowAssetLinkMixin.js
@@ -26,7 +26,7 @@ export default {
       }
       let assets = this.data.getAssets();
       if (!this.showThumbnailsAsAssets) {
-        assets = assets.filter(asset => !this.thumbnails.includes(asset));
+        assets = assets.filter(asset => !this.isThumbnail(asset));
       }
       return assets;
     },
@@ -56,8 +56,11 @@ export default {
     }
   },
   methods: {
+    isThumbnail(asset) {
+      return this.thumbnails.some(t => t.is(asset) || (t.isAlternate && t.getContext()?.is(asset)));
+    },
     showAsset(asset) {
-      if (this.thumbnails.find(t => t.is(asset))) {
+      if (this.isThumbnail(asset)) {
         this.tab = this.tabIds.thumbnails;
       }
       else {

--- a/src/components/ShowAssetLinkMixin.js
+++ b/src/components/ShowAssetLinkMixin.js
@@ -56,8 +56,26 @@ export default {
     }
   },
   methods: {
+    isAssetEqual(a, b) {
+      if (!a?.isAsset || !b?.isAsset) {
+        return false;
+      }
+      if (a === b) {
+        return true;
+      }
+      if (a.getAbsoluteUrl() === b.getAbsoluteUrl()) {
+        return true;
+      }
+      if (a.isAlternate) {
+        return this.isAssetEqual(a.getContext(), b);
+      }
+      if (b.isAlternate) {
+        return this.isAssetEqual(a, b.getContext());
+      }
+      return false;
+    },
     isThumbnail(asset) {
-      return this.thumbnails.some(t => t.is(asset) || (t.isAlternate && t.getContext()?.is(asset)));
+      return this.thumbnails.some(t => this.isAssetEqual(t, asset));
     },
     showAsset(asset) {
       if (this.isThumbnail(asset)) {

--- a/tests/e2e/item.spec.js
+++ b/tests/e2e/item.spec.js
@@ -8,6 +8,7 @@ import { test, expect } from './fixtures.js';
 import { waitForBrowserReady } from './helpers.js';
 import StaticCatalog from '../fixtures/instances/static.js';
 import API from '../fixtures/instances/api.js';
+import { http, HttpResponse } from 'msw';
 
 test.describe('Item view - Metadata', () => {
   function createCatalog() {
@@ -213,6 +214,71 @@ test.describe('Item view - Assets', () => {
     // the expanded asset panel shows Download / Copy URL / Show on map buttons
     await expect(page.getByRole('button', { name: /download/i })).toBeVisible();
     await expect(page.getByRole('button', { name: /show on map/i })).toBeVisible();
+  });
+});
+
+test.describe('Item view - Alternate thumbnails', () => {
+  // A minimal 1x1 PNG, served for the HTTPS alternate of an S3-only thumbnail.
+  const PNG_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+  const THUMB_URL = 'https://stac.example/thumbnail-https.png';
+
+  function createCatalog() {
+    const catalog = new StaticCatalog({ url: 'https://stac.example/catalog.json' });
+    catalog.addCollection({ url: 'https://stac.example/collection.json' });
+    const item = catalog.addItem({ url: 'https://stac.example/item.json' });
+    // The thumbnail's main access mechanism is S3 (which a browser can't display),
+    // but it provides an HTTPS alternate that a browser *can* display. STAC Browser
+    // should fall back to the alternate. See
+    // https://github.com/radiantearth/stac-browser/issues/910
+    item.data.assets = {
+      thumbnail: {
+        href: 's3://example-bucket/thumbnail.png',
+        type: 'image/png',
+        roles: ['thumbnail'],
+        title: 'Thumbnail Image',
+        'alternate:name': 'S3',
+        alternate: {
+          https: {
+            href: THUMB_URL,
+            type: 'image/png',
+            'alternate:name': 'HTTPS'
+          }
+        }
+      }
+    };
+    item.addToExtensions('https://stac-extensions.github.io/alternate-assets/v1.2.0/schema.json');
+    return { catalog, item };
+  }
+
+  test('falls back to the HTTPS alternate and actually renders the image', async ({ page, worker }) => {
+    const { catalog, item } = createCatalog();
+    await catalog.createServer(worker);
+    // Serve an actual image for the HTTPS alternate (added after createServer,
+    // which resets handlers).
+    await worker.use(
+      http.get(THUMB_URL, () => {
+        const bytes = Uint8Array.from(atob(PNG_BASE64), c => c.charCodeAt(0));
+        return new HttpResponse(bytes, { headers: { 'Content-Type': 'image/png' } });
+      })
+    );
+
+    await page.goto(item.getBrowserPath());
+    await waitForBrowserReady(page);
+
+    // Open the thumbnails tab.
+    const thumbTab = page.getByRole('tab', { name: /thumbnails/i });
+    await thumbTab.click();
+    await expect(page.getByRole('tabpanel', { name: /thumbnails/i })).toBeVisible();
+
+    // The rendered thumbnail must use the HTTPS alternate URL, not the S3 href.
+    const img = page.locator('img.thumbnail');
+    await expect(img).toBeVisible();
+    await expect(img).toHaveAttribute('src', THUMB_URL);
+
+    // And the image must have actually loaded (decoded to a non-zero size).
+    await expect
+      .poll(() => img.evaluate(el => el.complete && el.naturalWidth > 0))
+      .toBe(true);
   });
 });
 


### PR DESCRIPTION
## Proposed Changes

Alternate assets are considered as thumbnail and preview candidates if the original asset can't be shown in a browser

Closes #910

## Checklist

- [x] Added [changelog entry](CHANGELOG.md)
- [x] Added translations for new or changed UI strings
- [x] Executed linter (`npm run lint`)
- [x] Added and executed tests (`npm test`)
