### PR TITLE
Allow setting pathPrefix at startup.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - The Browse menu also loads additional Collections on demand
+- `runtimeConfig` build option (`SB_runtimeConfig`) for post-build configuration.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - The Browse menu also loads additional Collections on demand
-- `runtimeConfig` build option (`SB_runtimeConfig`) for post-build configuration.
+- Docker: `pathPrefix` can be set at container startup via `SB_pathPrefix` when `DYNAMIC_CONFIG` is enabled (default)
 
 ### Changed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,42 +1,37 @@
-ARG pathPrefix="/"
-
 FROM node:lts-alpine AS build-step
-ARG DYNAMIC_CONFIG=true
+ARG runtimeConfig=true
 ARG historyMode="history"
-ARG pathPrefix
 ARG SB_CONFIG=""
+ENV SB_runtimeConfig="${runtimeConfig}"
 ENV SB_historyMode="${historyMode}"
-ENV SB_pathPrefix="${pathPrefix}"
 ENV SB_CONFIG="${SB_CONFIG}"
 
 WORKDIR /app
 COPY package*.json ./
 RUN npm install
 COPY . .
-RUN \[ "${DYNAMIC_CONFIG}" == "true" \] && sed -i 's/<!--RC//;s/RC-->//' index.html
 RUN npm run build
 
 
 FROM nginxinc/nginx-unprivileged:1-alpine
-ARG pathPrefix
+ARG pathPrefix="/"
 
 USER root
 RUN apk add --no-cache jq pcre-tools
 
 COPY ./config.schema.json /etc/nginx/conf.d/config.schema.json
 COPY --from=build-step /app/dist /usr/share/nginx/html
-COPY --from=build-step /app/docker/default.conf /etc/nginx/conf.d/default.conf
+COPY --from=build-step /app/docker/default.conf /etc/nginx/conf.d/default.conf.template
 ADD docker/docker-entrypoint.sh /docker-entrypoint.d/40-stac-browser-entrypoint.sh
 
-RUN barePrefix=$(printf '%s' "${pathPrefix}" | sed 's|/*$||') && \
-    if [ -n "${barePrefix}" ]; then \
-      sed -i "s|<prefixRedirect>|location = ${barePrefix} { return 301 ${barePrefix}/\$is_args\$args; }|" /etc/nginx/conf.d/default.conf; \
-    else \
-      sed -i '/<prefixRedirect>/d' /etc/nginx/conf.d/default.conf; \
-    fi && \
-    sed -i "s|<pathPrefix>|${pathPrefix}|" /etc/nginx/conf.d/default.conf && \
+# Remove the base image's default server config so nginx fails loudly if the
+# entrypoint (which renders default.conf.template) is bypassed, instead of
+# silently serving the stock nginx welcome page.
+RUN rm -f /etc/nginx/conf.d/default.conf && \
     chown -R nginx:nginx /usr/share/nginx/html && \
     chmod +x /docker-entrypoint.d/40-stac-browser-entrypoint.sh
+
+ENV SB_pathPrefix="${pathPrefix}"
 
 EXPOSE 8080
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM node:lts-alpine AS build-step
-ARG runtimeConfig=true
+ARG DYNAMIC_CONFIG=true
 ARG historyMode="history"
 ARG SB_CONFIG=""
-ENV SB_runtimeConfig="${runtimeConfig}"
+ENV DYNAMIC_CONFIG="${DYNAMIC_CONFIG}"
 ENV SB_historyMode="${historyMode}"
 ENV SB_CONFIG="${SB_CONFIG}"
 
@@ -10,6 +10,7 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm install
 COPY . .
+RUN \[ "${DYNAMIC_CONFIG}" == "true" \] && sed -i 's/<!--RC//;s/RC-->//' index.html
 RUN npm run build
 
 
@@ -24,9 +25,7 @@ COPY --from=build-step /app/dist /usr/share/nginx/html
 COPY --from=build-step /app/docker/default.conf /etc/nginx/conf.d/default.conf.template
 ADD docker/docker-entrypoint.sh /docker-entrypoint.d/40-stac-browser-entrypoint.sh
 
-# Remove the base image's default server config so nginx fails loudly if the
-# entrypoint (which renders default.conf.template) is bypassed, instead of
-# silently serving the stock nginx welcome page.
+# Remove default.conf so a skipped entrypoint fails loudly instead of serving nginx's welcome page.
 RUN rm -f /etc/nginx/conf.d/default.conf && \
     chown -R nginx:nginx /usr/share/nginx/html && \
     chmod +x /docker-entrypoint.d/40-stac-browser-entrypoint.sh

--- a/config.js
+++ b/config.js
@@ -41,6 +41,7 @@ export default {
   buildTileUrlTemplate: null,
   getMapSourceOptions: null,
   pathPrefix: "/",
+  runtimeConfig: false,
   historyMode: "history",
   cardViewMode: "cards",
   defaultCollectionSort: "title",

--- a/config.js
+++ b/config.js
@@ -41,7 +41,6 @@ export default {
   buildTileUrlTemplate: null,
   getMapSourceOptions: null,
   pathPrefix: "/",
-  runtimeConfig: false,
   historyMode: "history",
   cardViewMode: "cards",
   defaultCollectionSort: "title",

--- a/config.schema.json
+++ b/config.schema.json
@@ -81,7 +81,10 @@
       "noEnv": true
     },
     "pathPrefix": {
-      "type": ["string"],
+      "type": ["string"]
+    },
+    "runtimeConfig": {
+      "type": ["boolean"],
       "buildOnly": true
     },
     "historyMode": {

--- a/config.schema.json
+++ b/config.schema.json
@@ -83,10 +83,6 @@
     "pathPrefix": {
       "type": ["string"]
     },
-    "runtimeConfig": {
-      "type": ["boolean"],
-      "buildOnly": true
-    },
     "historyMode": {
       "type": ["string"],
       "enum": ["history", "hash"],

--- a/docker/default.conf
+++ b/docker/default.conf
@@ -3,11 +3,11 @@ server {
     server_name  localhost;
     absolute_redirect off;
 
-    <prefixRedirect>
-    location <pathPrefix> {
+    ${STAC_PREFIX_REDIRECT}
+    location ${STAC_PATH_PREFIX} {
         alias  /usr/share/nginx/html/;
         index  index.html;
-        try_files $uri $uri/ <pathPrefix>index.html;
+        try_files $uri $uri/ ${STAC_PATH_PREFIX}index.html;
     }
 
     error_page   500 502 503 504  /50x.html;

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -61,10 +61,40 @@ object() {
     fi
 }
 
+STAC_PATH_PREFIX=$(printf '%s' "${SB_pathPrefix:-/}" | sed -e 's|^/*|/|' -e 's|/*$|/|')
+
+# Reject characters that could inject nginx directives or break the sed/envsubst substitutions below.
+if printf '%s' "$STAC_PATH_PREFIX" | grep -Eq '[&|;{}"'"'"'[:space:]\\]'; then
+    echo "Err: SB_pathPrefix contains unsupported characters: ${SB_pathPrefix}" >&2
+    exit 1
+fi
+
+export SB_pathPrefix="$STAC_PATH_PREFIX"
+export STAC_PATH_PREFIX
+
+barePrefix=$(printf '%s' "$STAC_PATH_PREFIX" | sed 's|/*$||')
+if [ -n "$barePrefix" ] && [ "$barePrefix" != "/" ]; then
+    STAC_PREFIX_REDIRECT="location = ${barePrefix} { return 301 ${STAC_PATH_PREFIX}\$is_args\$args; }"
+else
+    STAC_PREFIX_REDIRECT=""
+fi
+export STAC_PREFIX_REDIRECT
+
+envsubst '$STAC_PATH_PREFIX $STAC_PREFIX_REDIRECT' \
+    < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
+
+# Rewrite the <base> tag so relative asset URLs (Vite `base: "./"`) resolve
+# against the path prefix instead of the current document URL, otherwise deep
+# links (e.g. /browser/collections/x) would try to load assets from the wrong path.
+if [ -f /usr/share/nginx/html/index.html ]; then
+    sed -i "s|<base href=\"[^\"]*\" id=\"stac-browser-base\">|<base href=\"${STAC_PATH_PREFIX}\" id=\"stac-browser-base\">|" \
+        /usr/share/nginx/html/index.html
+fi
+
 config_schema=$(cat /etc/nginx/conf.d/config.schema.json)
 
 # Iterate over environment variables with "SB_" prefix
-env -0 | cut -f1 -d= | tr '\0' '\n' | grep "^SB_" | {
+env -0 | tr '\0' '\n' | cut -f1 -d= | grep "^SB_" | {
     echo "window.STAC_BROWSER_CONFIG = {"
     while IFS='=' read -r name; do
         # Strip the prefix

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -83,9 +83,7 @@ export STAC_PREFIX_REDIRECT
 envsubst '$STAC_PATH_PREFIX $STAC_PREFIX_REDIRECT' \
     < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
 
-# Rewrite the <base> tag so relative asset URLs (Vite `base: "./"`) resolve
-# against the path prefix instead of the current document URL, otherwise deep
-# links (e.g. /browser/collections/x) would try to load assets from the wrong path.
+# Point <base> at the runtime path prefix (Vite builds with base "./").
 if [ -f /usr/share/nginx/html/index.html ]; then
     sed -i "s|<base href=\"[^\"]*\" id=\"stac-browser-base\">|<base href=\"${STAC_PATH_PREFIX}\" id=\"stac-browser-base\">|" \
         /usr/share/nginx/html/index.html

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -64,8 +64,8 @@ object() {
 
 STAC_PATH_PREFIX=$(printf '%s' "${SB_pathPrefix:-/}" | sed -e 's|^/*|/|' -e 's|/*$|/|')
 
-# Reject characters that could inject nginx directives or break the sed/envsubst substitutions below.
-if printf '%s' "$STAC_PATH_PREFIX" | grep -Eq '[&|;{}"'"'"'[:space:]\\]'; then
+# Allow only URL path-safe characters so values cannot break nginx/sed/envsubst.
+if ! printf '%s' "$STAC_PATH_PREFIX" | grep -Eq '^[A-Za-z0-9/_.~-]+$'; then
     echo "Err: SB_pathPrefix contains unsupported characters: ${SB_pathPrefix}" >&2
     exit 1
 fi
@@ -81,6 +81,8 @@ else
 fi
 export STAC_PREFIX_REDIRECT
 
+# Single-quoted so the shell does not expand; envsubst expands these names.
+# shellcheck disable=SC2016
 envsubst '$STAC_PATH_PREFIX $STAC_PREFIX_REDIRECT' \
     < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
 
@@ -91,6 +93,8 @@ if [ -f /usr/share/nginx/html/index.html ]; then
 fi
 
 config_schema=$(cat /etc/nginx/conf.d/config.schema.json)
+runtime_config_tmp=/usr/share/nginx/html/runtime-config.js.tmp
+runtime_config=/usr/share/nginx/html/runtime-config.js
 
 # Iterate over environment variables with "SB_" prefix
 env -0 | tr '\0' '\n' | cut -f1 -d= | grep "^SB_" | {
@@ -127,4 +131,5 @@ env -0 | tr '\0' '\n' | cut -f1 -d= | grep "^SB_" | {
         echo ","
     done
     echo "}"
-} > /usr/share/nginx/html/runtime-config.js
+} > "$runtime_config_tmp"
+mv -f "$runtime_config_tmp" "$runtime_config"

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -88,7 +88,7 @@ services:
 ## How it works
 
 The docker image uses a multi stage build.
-The first stage is based on a node image and runs `npm build` to produce a `/dist` folder with static files (HTML, CSS, and JavaScript).
+The first stage is based on a node image and runs `npm run build` to produce a `/dist` folder with static files (HTML, CSS, and JavaScript).
 The second stage is based on an nginx image that serves the folder with static files. At startup, the entrypoint applies `SB_pathPrefix` to nginx and generates `runtime-config.js`.
 So, essentially, in the end you get an nginx instance that serves static files.
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -31,7 +31,7 @@ STAC Browser is now available at `http://localhost:8080`
 You can pass further options to STAC Browser to customize it to your needs.
 
 The build-only options
-[`pathPrefix`](./options.md#pathprefix), [`historyMode`](./options.md#historymode),
+[`runtimeConfig`](./options.md#runtimeconfig), [`historyMode`](./options.md#historymode),
 and `SB_CONFIG` (for loading an [external config file](./options.md))
 can be provided as a
 [build argument](https://docs.docker.com/engine/reference/commandline/build#set-build-time-variables---build-arg)
@@ -40,7 +40,7 @@ when building the Dockerfile.
 For example:
 
 ```bash
-docker build -t stac-browser:v1 --build-arg pathPrefix="/browser/" --build-arg historyMode=hash .
+docker build -t stac-browser:v1 --build-arg historyMode=hash .
 ```
 
 `SB_CONFIG` lets you overlay a custom config module (e.g. for options like
@@ -60,9 +60,15 @@ For example, to run the container with a pre-defined
 docker run -p 8080:8080 -e SB_catalogUrl="https://earth-search.aws.element84.com/v1/" -e SB_catalogTitle="Earth Search" stac-browser:v1
 ```
 
+[`pathPrefix`](./options.md#pathprefix) can also be set at container startup via `SB_pathPrefix` (no rebuild required when [`runtimeConfig`](./options.md#runtimeconfig) is enabled, as in the Docker image):
+
+```bash
+docker run -p 8080:8080 -e SB_pathPrefix="/browser/" -e SB_catalogUrl="https://earth-search.aws.element84.com/v1/" stac-browser:v1
+```
+
 If you want to pass all the other arguments to `npm run build` directly, you can modify to the Dockerfile as needed.
 
-STAC Browser is now available at `http://localhost:8080/browser/`.
+STAC Browser is then available at `http://localhost:8080/browser/`.
 Requests to `http://localhost:8080/browser` (no trailing slash) are redirected there.
 
 ## Use an existing image
@@ -83,20 +89,20 @@ services:
 
 The docker image uses a multi stage build.
 The first stage is based on a node image and runs `npm build` to produce a `/dist` folder with static files (HTML, CSS, and JavaScript).
-The second stage is based on an nginx image that serves the folder with static files and deals with the build-only options such as  `pathPrefix`.
+The second stage is based on an nginx image that serves the folder with static files. At startup, the entrypoint renders the nginx path prefix from `SB_pathPrefix` and generates `runtime-config.js` from `SB_*` environment variables.
 So, essentially, in the end you get an nginx instance that serves static files.
 
 ## Essential parts
 
 1. [Dockerfile](../Dockerfile) - contains information on how to build the image.
-2. [docker/default.conf](../docker/default.conf) - nginx configuration template. During build, `<pathPrefix>` is replaced and a bare-prefix redirect is added when `pathPrefix` is not `/`.
-3. [docker/docker-entrypoint.sh](../docker/docker-entrypoint.sh) - a start script to read the passed variables and produce the `runtime-config.js` file.
+2. [docker/default.conf](../docker/default.conf) - nginx configuration template. `${STAC_PATH_PREFIX}` and a bare-prefix redirect are substituted at startup when `pathPrefix` is not `/`.
+3. [docker/docker-entrypoint.sh](../docker/docker-entrypoint.sh) - a start script to read the passed variables, render the nginx config, and produce the `runtime-config.js` file.
 
 ## FAQ
 
 > Can I use `ghcr.io/radiantearth/stac-browser` image with the `pathPrefix`?
 
-You can not. You need to build your own image because `pathPrefix` is a build-only option.
+Yes — pass `-e SB_pathPrefix="/browser/"` at container startup. See [`pathPrefix`](./options.md#pathprefix).
 
 > How do I specify `buildTileUrlTemplate` via docker env?
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -31,7 +31,7 @@ STAC Browser is now available at `http://localhost:8080`
 You can pass further options to STAC Browser to customize it to your needs.
 
 The build-only options
-[`runtimeConfig`](./options.md#runtimeconfig), [`historyMode`](./options.md#historymode),
+[`historyMode`](./options.md#historymode)
 and `SB_CONFIG` (for loading an [external config file](./options.md))
 can be provided as a
 [build argument](https://docs.docker.com/engine/reference/commandline/build#set-build-time-variables---build-arg)
@@ -60,7 +60,7 @@ For example, to run the container with a pre-defined
 docker run -p 8080:8080 -e SB_catalogUrl="https://earth-search.aws.element84.com/v1/" -e SB_catalogTitle="Earth Search" stac-browser:v1
 ```
 
-[`pathPrefix`](./options.md#pathprefix) can also be set at container startup via `SB_pathPrefix` (no rebuild required when [`runtimeConfig`](./options.md#runtimeconfig) is enabled, as in the Docker image):
+[`pathPrefix`](./options.md#pathprefix) can also be set at container startup via `SB_pathPrefix` (when `DYNAMIC_CONFIG` is enabled, the default):
 
 ```bash
 docker run -p 8080:8080 -e SB_pathPrefix="/browser/" -e SB_catalogUrl="https://earth-search.aws.element84.com/v1/" stac-browser:v1
@@ -68,7 +68,7 @@ docker run -p 8080:8080 -e SB_pathPrefix="/browser/" -e SB_catalogUrl="https://e
 
 If you want to pass all the other arguments to `npm run build` directly, you can modify to the Dockerfile as needed.
 
-STAC Browser is then available at `http://localhost:8080/browser/`.
+STAC Browser is now available at `http://localhost:8080/browser/`.
 Requests to `http://localhost:8080/browser` (no trailing slash) are redirected there.
 
 ## Use an existing image
@@ -89,13 +89,13 @@ services:
 
 The docker image uses a multi stage build.
 The first stage is based on a node image and runs `npm build` to produce a `/dist` folder with static files (HTML, CSS, and JavaScript).
-The second stage is based on an nginx image that serves the folder with static files. At startup, the entrypoint renders the nginx path prefix from `SB_pathPrefix` and generates `runtime-config.js` from `SB_*` environment variables.
+The second stage is based on an nginx image that serves the folder with static files. At startup, the entrypoint applies `SB_pathPrefix` to nginx and generates `runtime-config.js`.
 So, essentially, in the end you get an nginx instance that serves static files.
 
 ## Essential parts
 
 1. [Dockerfile](../Dockerfile) - contains information on how to build the image.
-2. [docker/default.conf](../docker/default.conf) - nginx configuration template. `${STAC_PATH_PREFIX}` and a bare-prefix redirect are substituted at startup when `pathPrefix` is not `/`.
+2. [docker/default.conf](../docker/default.conf) - nginx configuration template; `${STAC_PATH_PREFIX}` is substituted at startup.
 3. [docker/docker-entrypoint.sh](../docker/docker-entrypoint.sh) - a start script to read the passed variables, render the nginx config, and produce the `runtime-config.js` file.
 
 ## FAQ

--- a/docs/options.md
+++ b/docs/options.md
@@ -16,8 +16,9 @@ The following ways to set config options are possible:
   `SB_requestHeaders='{"Authorization":"Bearer …"}'`.
   For convenience, array options that only contain strings may also be given as a comma-separated list, e.g. `SB_supportedLocales=en,de,fr`.
 - Optionally, you can also set options after the build, basically **at "runtime"**.
-  Enable this by removing the `<!--RC` and `RC-->` around the `script` tag that loads the `runtime-config.js` in the [`index.html`](../index.html).
-  Then run the build procedure and after completion, you can fill the `dist/runtime-config.js` with any options that you want to customize.
+  Enable this by setting [`runtimeConfig`](#runtimeconfig) to `true` (`SB_runtimeConfig` when building), which injects a `runtime-config.js` script tag.
+  Then fill `runtime-config.js` with any options you want to customize at deploy or startup — including [`pathPrefix`](#pathprefix).
+  The [Docker image](./docker.md) does this automatically from `SB_*` environment variables.
 
 > [!TIP]  
 > To enable the usage of a local configuration file, follow these steps:
@@ -54,6 +55,7 @@ The override order for the configuration is:
   - [footerLinks](#footerlinks)
   - [apiCatalogPriority](#apicatalogpriority)
 - [Deployment](#deployment)
+  - [runtimeConfig](#runtimeconfig)
   - [historyMode](#historymode)
     - [`history`](#history)
     - [`hash`](#hash)
@@ -173,6 +175,14 @@ The following options are available:
 
 ## Deployment
 
+### runtimeConfig
+
+***build-only option***
+
+When `true`, the build injects a `runtime-config.js` script tag and uses relative asset URLs so one build supports different deploy settings (notably [`pathPrefix`](#pathprefix)).
+
+Set in [`config.js`](../config.js) or via `SB_runtimeConfig`. The [Docker image](./docker.md) defaults to `true`.
+
 ### historyMode
 
 ***build-only option***
@@ -203,12 +213,11 @@ Known hosts that require hash mode are Amazon S3 and GitHub Pages.
 
 ### pathPrefix
 
-***build-only option***
+If you don't deploy the STAC Browser instance at the root path of your (sub) domain, then you need to set the path prefix.
 
-If you don't deploy the STAC Browser instance at the root path of your (sub) domain, then you need to set the path prefix
-when building (or running) STAC Browser. Known hosts that require hash mode are Amazon S3 and GitHub Pages.
+Either set this option to the respective path (e.g. `/browser/`) in the config file or as environment variable (`SB_pathPrefix`) when building or running.
 
-Either set this option to the respective path (e.g. `/browser/`) in the config file or as environment variable (`SB_pathPrefix`) when running or building.
+When [`runtimeConfig`](#runtimeconfig) is enabled, `pathPrefix` can be set at deploy or startup via `runtime-config.js` or `SB_pathPrefix` instead of at build time. The build uses relative asset URLs plus a `<base>` tag in `index.html` for this, so outside of the [Docker image](./docker.md) (which rewrites it automatically) you also need to update the `href` of the `<base id="stac-browser-base">` tag in `dist/index.html` to match.
 
 This will build STAC Browser in a way that it can be hosted at `https://example.com/browser` for example.
 Using this parameter for the dev server will make STAC Browser available at `http://localhost:8080/browser`.

--- a/docs/options.md
+++ b/docs/options.md
@@ -16,9 +16,8 @@ The following ways to set config options are possible:
   `SB_requestHeaders='{"Authorization":"Bearer …"}'`.
   For convenience, array options that only contain strings may also be given as a comma-separated list, e.g. `SB_supportedLocales=en,de,fr`.
 - Optionally, you can also set options after the build, basically **at "runtime"**.
-  Enable this by setting [`runtimeConfig`](#runtimeconfig) to `true` (`SB_runtimeConfig` when building), which injects a `runtime-config.js` script tag.
-  Then fill `runtime-config.js` with any options you want to customize at deploy or startup — including [`pathPrefix`](#pathprefix).
-  The [Docker image](./docker.md) does this automatically from `SB_*` environment variables.
+  Enable this by removing the `<!--RC` and `RC-->` around the tags that load the `runtime-config.js` (and the `<base>` tag) in the [`index.html`](../index.html).
+  Then run the build procedure and after completion, you can fill the `dist/runtime-config.js` with any options that you want to customize.
 
 > [!TIP]  
 > To enable the usage of a local configuration file, follow these steps:
@@ -55,7 +54,6 @@ The override order for the configuration is:
   - [footerLinks](#footerlinks)
   - [apiCatalogPriority](#apicatalogpriority)
 - [Deployment](#deployment)
-  - [runtimeConfig](#runtimeconfig)
   - [historyMode](#historymode)
     - [`history`](#history)
     - [`hash`](#hash)
@@ -175,14 +173,6 @@ The following options are available:
 
 ## Deployment
 
-### runtimeConfig
-
-***build-only option***
-
-When `true`, the build injects a `runtime-config.js` script tag and uses relative asset URLs so one build supports different deploy settings (notably [`pathPrefix`](#pathprefix)).
-
-Set in [`config.js`](../config.js) or via `SB_runtimeConfig`. The [Docker image](./docker.md) defaults to `true`.
-
 ### historyMode
 
 ***build-only option***
@@ -213,11 +203,12 @@ Known hosts that require hash mode are Amazon S3 and GitHub Pages.
 
 ### pathPrefix
 
-If you don't deploy the STAC Browser instance at the root path of your (sub) domain, then you need to set the path prefix.
+If you don't deploy the STAC Browser instance at the root path of your (sub) domain, then you need to set the path prefix
+when building (or running) STAC Browser.
 
-Either set this option to the respective path (e.g. `/browser/`) in the config file or as environment variable (`SB_pathPrefix`) when building or running.
+Either set this option to the respective path (e.g. `/browser/`) in the config file or as environment variable (`SB_pathPrefix`) when running or building.
 
-When [`runtimeConfig`](#runtimeconfig) is enabled, `pathPrefix` can be set at deploy or startup via `runtime-config.js` or `SB_pathPrefix` instead of at build time. The build uses relative asset URLs plus a `<base>` tag in `index.html` for this, so outside of the [Docker image](./docker.md) (which rewrites it automatically) you also need to update the `href` of the `<base id="stac-browser-base">` tag in `dist/index.html` to match.
+With `DYNAMIC_CONFIG` (default in the [Docker image](./docker.md)), `pathPrefix` can instead be set at startup via `SB_pathPrefix` / `runtime-config.js`. Outside Docker, also set the `href` of `<base id="stac-browser-base">` in `dist/index.html` to match.
 
 This will build STAC Browser in a way that it can be hosted at `https://example.com/browser` for example.
 Using this parameter for the dev server will make STAC Browser available at `http://localhost:8080/browser`.

--- a/index.html
+++ b/index.html
@@ -11,7 +11,10 @@
     <meta name="og:description" id="og-description" content="">
     <meta name="og:locale" id="og-locale" content="en">
     <meta name="og:site_name" content="<%- catalogTitle %>">
-    <!--RC <script defer="defer" src="<%- pathPrefix %>runtime-config.js"></script> RC-->
+    <% if (runtimeConfig) { %>
+    <base href="<%- pathPrefix %>" id="stac-browser-base">
+    <script defer="defer" src="./runtime-config.js"></script>
+    <% } %>
     <title><%- catalogTitle %></title>
   </head>
   <body>

--- a/index.html
+++ b/index.html
@@ -11,10 +11,10 @@
     <meta name="og:description" id="og-description" content="">
     <meta name="og:locale" id="og-locale" content="en">
     <meta name="og:site_name" content="<%- catalogTitle %>">
-    <% if (runtimeConfig) { %>
+    <!--RC
     <base href="<%- pathPrefix %>" id="stac-browser-base">
     <script defer="defer" src="./runtime-config.js"></script>
-    <% } %>
+    RC-->
     <title><%- catalogTitle %></title>
   </head>
   <body>

--- a/tests/docker/run-tests.sh
+++ b/tests/docker/run-tests.sh
@@ -26,19 +26,31 @@ echo "✓ Docker build passed"
 echo "── Testing runtime configuration ──"
 allowed_domains="example.com,quote's.test,back\\slash.test"
 catalog_title=$'Earth\'s \\ catalog\nSecond line'
+path_prefix="/browser/"
 container_id="$(
   docker run --detach --rm \
     --env "SB_allowedDomains=$allowed_domains" \
     --env "SB_catalogTitle=$catalog_title" \
+    --env "SB_pathPrefix=$path_prefix" \
     "$DOCKER_IMAGE"
 )"
 
-runtime_config="$(
-  docker exec "$container_id" \
-    cat /usr/share/nginx/html/runtime-config.js
-)"
+runtime_config=""
+for _ in $(seq 1 50); do
+  # Image ships an empty stub (`window.STAC_BROWSER_CONFIG = {};`); wait for the
+  # entrypoint to replace it. pathPrefix is always written by the entrypoint.
+  if runtime_config="$(docker exec "$container_id" cat /usr/share/nginx/html/runtime-config.js 2>/dev/null)" \
+    && [[ "$runtime_config" == *'pathPrefix:'* ]]; then
+    break
+  fi
+  sleep 0.1
+done
+if [[ "$runtime_config" != *'pathPrefix:'* ]]; then
+  echo "Runtime config was not generated in time" >&2
+  exit 1
+fi
 
-RUNTIME_CONFIG="$runtime_config" node <<'NODE'
+RUNTIME_CONFIG="$runtime_config" PATH_PREFIX="$path_prefix" node <<'NODE'
 const assert = require("node:assert/strict");
 
 global.window = {};
@@ -53,5 +65,29 @@ assert.equal(
   window.STAC_BROWSER_CONFIG.catalogTitle,
   "Earth's \\ catalog\nSecond line",
 );
+assert.equal(window.STAC_BROWSER_CONFIG.pathPrefix, process.env.PATH_PREFIX);
 NODE
+
+nginx_conf="$(docker exec "$container_id" cat /etc/nginx/conf.d/default.conf)"
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo "Expected nginx config to contain: $needle" >&2
+    echo "$haystack" >&2
+    exit 1
+  fi
+}
+assert_contains "$nginx_conf" "location ${path_prefix}"
+assert_contains "$nginx_conf" "location = /browser"
+
+base_href="$(
+  docker exec "$container_id" \
+    sed -n 's/.*<base href="\([^"]*\)" id="stac-browser-base">.*/\1/p' /usr/share/nginx/html/index.html
+)"
+if [[ "$base_href" != "$path_prefix" ]]; then
+  echo "Expected <base href=\"$path_prefix\">, got: $base_href" >&2
+  exit 1
+fi
+
 echo "✓ Runtime configuration passed"

--- a/vite.config.js
+++ b/vite.config.js
@@ -97,13 +97,15 @@ export default defineConfig(async ({ mode }) => {
   const defaultConfig = (await import(pathToFileURL(defaultConfigPath).href)).default ?? {};
   const externalConfig = (await import(pathToFileURL(externalConfigPath).href)).default ?? {};
   const config = Object.assign({}, defaultConfig, externalConfig, env);
-  const runtimeConfig = Boolean(config.runtimeConfig);
-  const configFromEnv = runtimeConfig
-    ? Object.fromEntries(Object.entries(env).filter(([key]) => key !== "pathPrefix"))
+  const dynamicConfig = ["true", "1", "yes"].includes(
+    String(rawEnv.DYNAMIC_CONFIG || "").toLowerCase()
+  );
+  const configFromEnv = dynamicConfig
+    ? Object.fromEntries(Object.entries(env).filter(([k]) => k !== "pathPrefix"))
     : env;
 
   return ({
-    base: runtimeConfig ? "./" : config.pathPrefix,
+    base: dynamicConfig ? "./" : config.pathPrefix,
     build: {
       sourcemap: mode !== "minimal",
       rollupOptions: {

--- a/vite.config.js
+++ b/vite.config.js
@@ -97,9 +97,13 @@ export default defineConfig(async ({ mode }) => {
   const defaultConfig = (await import(pathToFileURL(defaultConfigPath).href)).default ?? {};
   const externalConfig = (await import(pathToFileURL(externalConfigPath).href)).default ?? {};
   const config = Object.assign({}, defaultConfig, externalConfig, env);
+  const runtimeConfig = Boolean(config.runtimeConfig);
+  const configFromEnv = runtimeConfig
+    ? Object.fromEntries(Object.entries(env).filter(([key]) => key !== "pathPrefix"))
+    : env;
 
   return ({
-    base: config.pathPrefix,
+    base: runtimeConfig ? "./" : config.pathPrefix,
     build: {
       sourcemap: mode !== "minimal",
       rollupOptions: {
@@ -119,7 +123,7 @@ export default defineConfig(async ({ mode }) => {
       STAC_BROWSER_VERSION: JSON.stringify(package_.version),
       // JSON.stringify removes e.g. functions from the config,
       // but from env we do not accept functions anyway.
-      CONFIG_FROM_ENV: JSON.stringify(env),
+      CONFIG_FROM_ENV: JSON.stringify(configFromEnv),
       // Expose Vue component internals in the e2e build so end-to-end tests can
       // reach the OpenLayers map (see tests/e2e/helpers.js). Only enabled when the
       // e2e web server sets STAC_BROWSER_E2E; real production builds are unaffected.


### PR DESCRIPTION
## Proposed Changes

When running the STAC Browser container in a Kubernetes environment, it would be great to avoid having to rebuild (and maintain) a separate image per deployment. Instead, basic configuration should be loadable at startup.

I found "runtime" traces suggesting this approach is feasible, which is what led me to propose it here. Happy to discuss if a different approach is preferred.

## Checklist

- [x] Added [changelog entry](CHANGELOG.md)
- ~~[ ] Added translations for new or changed UI strings~~
- [x] Executed linter (`npm run lint`)
- ~~[ ] Added and executed tests (`npm test`)~~
