### PR TITLE
Make header sticky + redesign #931

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   **Note:** This is commonly used in `preprocessSTAC` config option, ensure to update your `config.js`.
 - Internal rewrite of how API children are maintained
 - Loaded collections are cached and no longer re-fetched when returning to a page
+- Header stays at the top by default and has a different design. You can disable the sticky header in the `variables.scss` by setting `$header-position` to `static`.
 
 ### Fixed
 

--- a/src/StacBrowser.vue
+++ b/src/StacBrowser.vue
@@ -6,31 +6,31 @@
     <ErrorAlert v-if="globalError" dismissible class="global-error" v-bind="globalError" @close="hideError" />
     <Sidebar v-if="sidebar !== null" v-model="sidebar" />
     <!-- Header -->
-    <header :class="{ scrolled }">
+    <header ref="header" :class="{ scrolled }">
       <b-row class="site">
         <b-col md="12">
           <nav class="actions navigation">
             <b-button-group v-if="canSearch || !isServerSelector">
-              <b-button v-if="!isServerSelector" variant="light" :title="$t('browse')" @click="sidebar = !sidebar">
+              <b-button v-if="!isServerSelector" variant="header" :title="$t('browse')" @click="sidebar = !sidebar">
                 <b-icon-list /><span class="button-label">{{ $t('browse') }}</span>
               </b-button>
-              <b-button v-if="canSearch" variant="light" :to="searchBrowserLink" :title="$t('search.title')" :pressed="isSearchPage">
+              <b-button v-if="canSearch" variant="header" :to="searchBrowserLink" :title="$t('search.title')" :pressed="isSearchPage">
                 <b-icon-search /><span class="button-label">{{ $t('search.title') }}</span>
               </b-button>
-              <b-button v-if="root" variant="light" id="popover-root-btn" tabindex="0">
+              <b-button v-if="root" variant="header" id="popover-root-btn" tabindex="0">
                 <b-icon-database /><span class="button-label">{{ serviceType }}</span>
               </b-button>
             </b-button-group>
           </nav>
           <div class="title">
             <StacLink v-if="root" :data="root">
-              <HeaderTitle ref="header" />
+              <HeaderTitle ref="headerTitle" />
             </StacLink>
-            <HeaderTitle v-else ref="header" />
+            <HeaderTitle v-else ref="headerTitle" />
           </div>
           <nav class="actions user">
             <b-button-group>
-              <b-button v-if="canAuthenticate" variant="light" @click="logInOut" :title="authTitle">
+              <b-button v-if="canAuthenticate" variant="header" @click="logInOut" :title="authTitle">
                 <component :is="authIcon" /><span class="button-label">{{ authLabel }}</span>
               </b-button>
               <LanguageChooser
@@ -40,7 +40,7 @@
               />
               <b-button
                 v-if="!enforcedColorModeFromVueX || enforcedColorModeFromVueX === 'auto'"
-                variant="light"
+                variant="header"
                 @click="toggleColorMode"
               >
                 <b-icon-sun v-if="colorMode === 'light'" :title="$t('switchToDarkMode')" />
@@ -377,6 +377,16 @@ export default defineComponent({
     },
     colorMode(value) {
       this.$store.commit('setColorMode', value);
+    },
+    scrollListener(newValue, oldValue) {
+      if (newValue) {
+        window.addEventListener('scroll', newValue, { passive: true });
+        // Initialize once, e.g. when the page is loaded already scrolled down.
+        newValue();
+      }
+      else {
+        window.removeEventListener('scroll', oldValue);
+      }
     }
   },
   async created() {
@@ -411,8 +421,8 @@ export default defineComponent({
       this.$store.commit(resetOp);
       this.parseQuery(to);
 
-      if (this.$refs.header) {
-        this.$refs.header.updateUrl();
+      if (this.$refs.headerTitle) {
+        this.$refs.headerTitle.updateUrl();
       }
     });
 
@@ -441,16 +451,16 @@ export default defineComponent({
 
     // Add scroll listener to show header shadow only when scrolled (and header is sticky)
     this.scrollListener = () => {
-      const header = this.$el.querySelector('header');
+      const header = this.$refs.header;
       const isSticky = header && window.getComputedStyle(header).position === 'sticky';
-      this.scrolled = isSticky && window.scrollY > 0;
+      const scrolled = Boolean(isSticky) && window.scrollY > 0;
+      if (scrolled !== this.scrolled) {
+        this.scrolled = scrolled;
+      }
     };
-    window.addEventListener('scroll', this.scrollListener, { passive: true });
   },
   beforeUnmount() {
-    if (this.scrollListener) {
-      window.removeEventListener('scroll', this.scrollListener);
-    }
+    this.scrollListener = null;
   },
   methods: {
     ...mapActions(['switchLocale', 'switchDataLocale']),

--- a/src/StacBrowser.vue
+++ b/src/StacBrowser.vue
@@ -6,18 +6,18 @@
     <ErrorAlert v-if="globalError" dismissible class="global-error" v-bind="globalError" @close="hideError" />
     <Sidebar v-if="sidebar !== null" v-model="sidebar" />
     <!-- Header -->
-    <header>
+    <header :class="{ scrolled }">
       <b-row class="site">
         <b-col md="12">
           <nav class="actions navigation">
             <b-button-group v-if="canSearch || !isServerSelector">
-              <b-button v-if="!isServerSelector" variant="primary" :title="$t('browse')" @click="sidebar = !sidebar">
+              <b-button v-if="!isServerSelector" variant="light" :title="$t('browse')" @click="sidebar = !sidebar">
                 <b-icon-list /><span class="button-label">{{ $t('browse') }}</span>
               </b-button>
-              <b-button v-if="canSearch" variant="primary" :to="searchBrowserLink" :title="$t('search.title')" :pressed="isSearchPage">
+              <b-button v-if="canSearch" variant="light" :to="searchBrowserLink" :title="$t('search.title')" :pressed="isSearchPage">
                 <b-icon-search /><span class="button-label">{{ $t('search.title') }}</span>
               </b-button>
-              <b-button v-if="root" variant="primary" id="popover-root-btn" tabindex="0">
+              <b-button v-if="root" variant="light" id="popover-root-btn" tabindex="0">
                 <b-icon-database /><span class="button-label">{{ serviceType }}</span>
               </b-button>
             </b-button-group>
@@ -30,7 +30,7 @@
           </div>
           <nav class="actions user">
             <b-button-group>
-              <b-button v-if="canAuthenticate" variant="primary" @click="logInOut" :title="authTitle">
+              <b-button v-if="canAuthenticate" variant="light" @click="logInOut" :title="authTitle">
                 <component :is="authIcon" /><span class="button-label">{{ authLabel }}</span>
               </b-button>
               <LanguageChooser
@@ -40,7 +40,7 @@
               />
               <b-button
                 v-if="!enforcedColorModeFromVueX || enforcedColorModeFromVueX === 'auto'"
-                variant="primary"
+                variant="light"
                 @click="toggleColorMode"
               >
                 <b-icon-sun v-if="colorMode === 'light'" :title="$t('switchToDarkMode')" />
@@ -170,7 +170,9 @@ export default defineComponent({
       sidebar: null,
       error: null,
       onDataLoaded: null,
-      isNavigatingLocale: false
+      isNavigatingLocale: false,
+      scrolled: false,
+      scrollListener: null
     };
   },
   computed: {
@@ -436,6 +438,19 @@ export default defineComponent({
         evt.preventDefault();
       }
     });
+
+    // Add scroll listener to show header shadow only when scrolled (and header is sticky)
+    this.scrollListener = () => {
+      const header = this.$el.querySelector('header');
+      const isSticky = header && window.getComputedStyle(header).position === 'sticky';
+      this.scrolled = isSticky && window.scrollY > 0;
+    };
+    window.addEventListener('scroll', this.scrollListener, { passive: true });
+  },
+  beforeUnmount() {
+    if (this.scrollListener) {
+      window.removeEventListener('scroll', this.scrollListener);
+    }
   },
   methods: {
     ...mapActions(['switchLocale', 'switchDataLocale']),

--- a/src/components/LanguageChooser.vue
+++ b/src/components/LanguageChooser.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-dropdown variant="light" right :title="$t('source.language.switch')">
+  <b-dropdown variant="header" right :title="$t('source.language.switch')">
     <template #button-content>
       <b-icon-flag /><span class="button-label">{{ $t('source.language.label', {currentLanguage}) }}</span>
     </template>

--- a/src/components/LanguageChooser.vue
+++ b/src/components/LanguageChooser.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-dropdown variant="primary" right :title="$t('source.language.switch')">
+  <b-dropdown variant="light" right :title="$t('source.language.switch')">
     <template #button-content>
       <b-icon-flag /><span class="button-label">{{ $t('source.language.label', {currentLanguage}) }}</span>
     </template>

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -93,6 +93,26 @@ export default {
     background-color: $dark;
   }
 
+  .btn-light {
+    --bs-btn-border-color: $light;
+  }
+
+  .btn-dark,
+  .badge-dark {
+    --bs-btn-border-color: $dark;
+  }
+
+  [data-bs-theme="dark"] {
+    .btn-light {
+      --bs-btn-border-color: $dark;
+    }
+
+    .btn-dark,
+    .badge-dark {
+      --bs-btn-border-color: $light;
+    }
+  }
+
   @include media-breakpoint-down(md) {
     width: 100%;
     min-width: 100px;

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -94,22 +94,19 @@ export default {
   }
 
   .btn-light {
-    --bs-btn-border-color: $light;
+    --bs-btn-border-color: #{$light};
+
+    [data-bs-theme="dark"] & {
+      --bs-btn-border-color: #{$dark};
+    }
   }
 
   .btn-dark,
   .badge-dark {
-    --bs-btn-border-color: $dark;
-  }
+    --bs-btn-border-color: #{$dark};
 
-  [data-bs-theme="dark"] {
-    .btn-light {
-      --bs-btn-border-color: $dark;
-    }
-
-    .btn-dark,
-    .badge-dark {
-      --bs-btn-border-color: $light;
+    [data-bs-theme="dark"] & {
+      --bs-btn-border-color: #{$light};
     }
   }
 

--- a/src/theme/page.scss
+++ b/src/theme/page.scss
@@ -32,7 +32,10 @@ svg {
   display: flex;
   flex-direction: column;
   max-width: 100%;
-  height: 100%;
+  // Only min-height, not height: a fixed height: 100% would cap this element's
+  // box at the viewport height, which in turn caps the sticky header's
+  // containing block and makes it scroll away past the first viewport. With
+  // min-height the container grows with its content and the header stays pinned.
   min-height: 100%;
   gap: var(--sb-block-gap);
 
@@ -41,9 +44,27 @@ svg {
   }
 
   > header {
+    position: $header-position;
+    margin-inline: calc(var(--bs-gutter-x, 1.5rem) * -0.5);
+    padding-inline: calc(var(--bs-gutter-x, 1.5rem) * 0.5);
+
+    @if $header-position == sticky {
+      top: var(--sb-header-margin);
+      z-index: $header-z-index;
+      box-shadow: none;
+      transition: box-shadow 0.2s ease-in-out;
+      background-color: var(--bs-body-bg);
+      border-bottom: 1px solid transparent;
+
+      &.scrolled {
+        border-bottom-color: var(--bs-border-color);
+        box-shadow: var(--bs-box-shadow-inset), 0 0.125rem 0.25rem rgba(0, 0, 0, 0.15);
+      }
+    }
+
     .site {
-      border-bottom: var(--sb-header-border);
-      
+      background: $header-background;
+
       @include media-breakpoint-up(lg) {
         .actions {
           min-width: 300px;
@@ -59,6 +80,16 @@ svg {
           display: flex;
           align-items: center;
           gap: var(--sb-header-font-size);
+          color: $link-color-on-primary;
+          text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);
+
+          a {
+            color: $link-color-on-primary;
+
+            &:hover {
+              color: $link-hover-color-on-primary;
+            }
+          }
           
           .header-title {
             display: flex;
@@ -239,7 +270,7 @@ svg {
 
   .service {
     &.bsky {
-      @include button-variant(#1185fe, #1185fe);
+      @include button-variant(#01A5FF, #01A5FF);
     }
     &.mastodon {
       @include button-variant(#6364ff, #6364ff);
@@ -342,7 +373,7 @@ svg {
     align-items: center;
     gap: 0.25rem;
     padding: 0.5rem;
-    background-color: rgba(0, 0, 0, 0.03);
+    background-color: rgba($body-color, 0.03);
     overflow: hidden;
 
     &::after {
@@ -600,7 +631,6 @@ svg {
   .multiselect__tags:focus-within {
     border-color: #{$input-focus-border-color};
     outline: 0;
-    // Matches Bootstrap's input focus ring, adapts to dark mode --bs-primary-rgb override
     box-shadow: var(--bs-box-shadow-inset), 0 0 0 0.25rem rgba(var(--bs-primary-rgb), 0.25);
   }
 
@@ -680,7 +710,7 @@ svg {
   left: 0;
   width: 100vw;
   height: 100vh;
-  background-color: rgba(0, 0, 0, 0.5);
+  background-color: rgba($body-color, 0.5);
   margin: auto;
   display: flex;
   justify-content: center;
@@ -700,13 +730,17 @@ svg {
     }
 
     > .card {
-      background-color: $body-bg;
-
-      [data-bs-theme="dark"] & {
-        background-color: $body-bg-dark;
-      }
+      background-color: var(--bs-body-bg);
     }
   }
+}
+
+.btn-light {
+  --bs-btn-border-color: #{shade-color($light, 20%)};
+}
+
+.btn-dark, .badge-dark {
+  --bs-btn-border-color: #{shade-color($dark, 20%)};
 }
 
 [data-bs-theme="dark"] {
@@ -722,7 +756,7 @@ svg {
   .btn-light {
     --bs-btn-color: #{$white};
     --bs-btn-bg: #{$dark};
-    --bs-btn-border-color: #{$dark};
+    --bs-btn-border-color: #{shade-color($dark, 20%)};
     --bs-btn-hover-color: #{$white};
     --bs-btn-hover-bg: #{shade-color($dark, 15%)};
     --bs-btn-hover-border-color: #{shade-color($dark, 20%)};
@@ -737,7 +771,7 @@ svg {
   .btn-dark, .badge-dark {
     --bs-btn-color: #{$dark};
     --bs-btn-bg: #{$light};
-    --bs-btn-border-color: #{$light};
+    --bs-btn-border-color: #{shade-color($light, 15%)};
     --bs-btn-hover-color: #{$dark};
     --bs-btn-hover-bg: #{shade-color($light, 15%)};
     --bs-btn-hover-border-color: #{shade-color($light, 20%)};
@@ -773,9 +807,6 @@ svg {
   // Colors (light mode; dark mode overrides below)
   --sb-h1-color: #{$h1-color};
   --sb-subheadings-color: #{$subheadings-color};
-
-  // Header border (color part stays live via var(--bs-primary))
-  --sb-header-border: #{$header-border-width} #{$header-border-style} var(--bs-primary);
 }
 
 [data-bs-theme="dark"] {

--- a/src/theme/page.scss
+++ b/src/theme/page.scss
@@ -20,12 +20,15 @@ svg {
   width: round(down, 1.2em, 1px);
 }
 
-.list-group-item.active a {
-  color: $link-color-on-primary;
-
-  &:hover {
-    color: $link-hover-color-on-primary;
-  }
+.list-group-item.active {
+  // Mark the selected item with Bootstrap's "subtle primary" tokens instead of
+  // a solid primary fill — the same treatment Bootstrap uses for an active
+  // accordion button. This keeps the text and any nested links readable with
+  // the normal colors (no on-primary special-casing) and is tuned for light
+  // and dark mode by Bootstrap.
+  --bs-list-group-active-color: var(--bs-primary-text-emphasis);
+  --bs-list-group-active-bg: var(--bs-primary-bg-subtle);
+  --bs-list-group-active-border-color: var(--bs-primary-border-subtle);
 }
 
 #stac-browser {
@@ -50,7 +53,7 @@ svg {
 
     @if $header-position == sticky {
       top: var(--sb-header-margin);
-      z-index: $header-z-index;
+      z-index: 1020;
       box-shadow: none;
       transition: box-shadow 0.2s ease-in-out;
       background-color: var(--bs-body-bg);
@@ -62,8 +65,35 @@ svg {
       }
     }
 
+    .btn-header {
+      @include button-variant(
+        $background: $header-button-background,
+        $border: $header-button-border-color,
+        $color: $header-color,
+        $hover-background: $header-button-hover-background,
+        $hover-border: $header-hover-button-border-color,
+        $hover-color: $header-hover-color,
+        $active-background: $header-button-active-background,
+        $active-border: $header-hover-button-border-color,
+        $active-color: $header-hover-color,
+        $disabled-background: transparent,
+        $disabled-border: transparent,
+        $disabled-color: rgba($header-color, 0.65)
+      );
+      --bs-btn-color: var(--sb-header-color);
+      --bs-btn-bg: var(--sb-header-button-background);
+      --bs-btn-border-color: var(--sb-header-button-border-color);
+      --bs-btn-hover-color: var(--sb-header-hover-color);
+      --bs-btn-hover-bg: var(--sb-header-button-hover-background);
+      --bs-btn-hover-border-color: var(--sb-header-hover-button-border-color);
+      --bs-btn-active-color: var(--sb-header-hover-color);
+      --bs-btn-active-bg: var(--sb-header-button-active-background);
+      --bs-btn-active-border-color: var(--sb-header-hover-button-border-color);
+      --bs-btn-disabled-color: color-mix(in srgb, var(--sb-header-color) 65%, transparent);
+    }
+
     .site {
-      background: $header-background;
+      background: var(--sb-header-background);
 
       @include media-breakpoint-up(lg) {
         .actions {
@@ -80,14 +110,14 @@ svg {
           display: flex;
           align-items: center;
           gap: var(--sb-header-font-size);
-          color: $link-color-on-primary;
-          text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);
+          color: var(--sb-header-color);
+          text-shadow: $header-text-shadow;
 
           a {
-            color: $link-color-on-primary;
+            color: var(--sb-header-color);
 
             &:hover {
-              color: $link-hover-color-on-primary;
+              color: var(--sb-header-hover-color);
             }
           }
           
@@ -140,12 +170,12 @@ svg {
           }
           @include media-breakpoint-down(xxl) {
             h1 {
-              font-size: $h1-font-size - 0.3rem;
+              font-size: $h1-font-size - 0.2rem;
             }
           }
           @include media-breakpoint-down(lg) {
             h1 {
-              font-size: $h1-font-size - 0.5rem;
+              font-size: $h1-font-size - 0.4rem;
             }
           }
         }
@@ -765,7 +795,7 @@ svg {
     --bs-btn-active-border-color: #{shade-color($dark, 25%)};
     --bs-btn-disabled-color: #{$white};
     --bs-btn-disabled-bg: #{$dark};
-    --bs-btn-disabled-border-color: #{$dark};
+    --bs-btn-disabled-border-color: #{shade-color($dark, 20%)};
   }
 
   .btn-dark, .badge-dark {
@@ -780,7 +810,7 @@ svg {
     --bs-btn-active-border-color: #{shade-color($light, 25%)};
     --bs-btn-disabled-color: #{$dark};
     --bs-btn-disabled-bg: #{$light};
-    --bs-btn-disabled-border-color: #{$light};
+    --bs-btn-disabled-border-color: #{shade-color($light, 15%)};
   }
 
   .text-bg-dark {
@@ -807,6 +837,21 @@ svg {
   // Colors (light mode; dark mode overrides below)
   --sb-h1-color: #{$h1-color};
   --sb-subheadings-color: #{$subheadings-color};
+
+  // Main/top header of the website
+  --sb-header: #{$header};
+  --sb-header-background: linear-gradient(to bottom,
+    color-mix(in srgb, var(--sb-header) 85%, #fff),
+    var(--sb-header),
+    color-mix(in srgb, var(--sb-header) 85%, #000)
+  );
+  --sb-header-color: #{$header-color};
+  --sb-header-hover-color: #{$header-hover-color};
+  --sb-header-button-background: #{$header-button-background};
+  --sb-header-button-border-color: #{$header-button-border-color};
+  --sb-header-button-hover-background: #{$header-button-hover-background};
+  --sb-header-button-active-background: #{$header-button-active-background};
+  --sb-header-hover-button-border-color: #{$header-hover-button-border-color};
 }
 
 [data-bs-theme="dark"] {

--- a/src/theme/variables.scss
+++ b/src/theme/variables.scss
@@ -61,8 +61,13 @@ $h4-font-size: 1.2rem;
 // Page header
 $header-font-size: 1.5rem;
 $header-font-weight: 600;
-$header-border-width: 3px;
-$header-border-style: solid;
+$header-position: sticky; // sticky or static
+$header-background: linear-gradient(to bottom, 
+  color-mix(in srgb, var(--bs-primary) 85%, #fff), 
+  var(--bs-primary), 
+  color-mix(in srgb, var(--bs-primary) 85%, #000)
+);
+$header-z-index: 1020;
 
 // Link decoration (non-color)
 $link-decoration: none;
@@ -98,7 +103,7 @@ $headings-color: inherit; // h3, h4, h5, h6
 $link-color: #188191;
 $link-hover-color: darken($link-color, 20%);
 
-$link-color-on-primary: tint-color($primary, 60%);
+$link-color-on-primary: tint-color($primary, 80%);
 $link-hover-color-on-primary: $body-bg;
 
 @import 'bootstrap/scss/_variables';

--- a/src/theme/variables.scss
+++ b/src/theme/variables.scss
@@ -51,23 +51,12 @@ $headings-font-family: $font-family-sans-serif;
 $font-family-monospace: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 
 // Heading sizes
-$h1-font-size: 2.2rem;
-$h1-font-weight: 700;
+$h1-font-size: 2rem;
+$h1-font-weight: 600;
 $h2-font-size: 1.6rem;
 $h2-font-weight: 600;
 $h3-font-size: 1.4rem;
 $h4-font-size: 1.2rem;
-
-// Page header
-$header-font-size: 1.5rem;
-$header-font-weight: 600;
-$header-position: sticky; // sticky or static
-$header-background: linear-gradient(to bottom, 
-  color-mix(in srgb, var(--bs-primary) 85%, #fff), 
-  var(--bs-primary), 
-  color-mix(in srgb, var(--bs-primary) 85%, #000)
-);
-$header-z-index: 1020;
 
 // Link decoration (non-color)
 $link-decoration: none;
@@ -97,16 +86,29 @@ $dark:      #343a40; // dark means highlighted
 // Heading colors
 $h1-color: inherit;
 $subheadings-color: #6c757d; // h2 only
-$headings-color: inherit; // h3, h4, h5, h6
 
 // Link colors
 $link-color: #188191;
 $link-hover-color: darken($link-color, 20%);
 
-$link-color-on-primary: tint-color($primary, 80%);
-$link-hover-color-on-primary: $body-bg;
-
 @import 'bootstrap/scss/_variables';
+
+// Main/top header of the website
+$header: $primary;
+$header-position: sticky; // sticky or static
+$header-font-size: 1.5rem;
+$header-font-weight: 600;
+$header-text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);
+
+$header-contrast: color-contrast($header);
+$header-color: tint-color($header, 80%); // Use shade-color if your header has a bright color
+$header-hover-color: $header-contrast;
+
+$header-button-background: transparent;
+$header-button-border-color: $header-color;
+$header-hover-button-border-color: $header-hover-color;
+$header-button-hover-background: rgba($header-contrast, 0.15);
+$header-button-active-background: rgba($header-contrast, 0.25);
 
 // ─────────────────────────────────────────────────────────
 // DARK MODE
@@ -121,7 +123,6 @@ $body-color-dark: #dee2e6;
 
 $h1-color-dark: inherit;
 $subheadings-color-dark: lighten($secondary, 10%);
-$headings-color-dark: inherit;
 
 $link-hover-color-dark: $body-color-dark;
 


### PR DESCRIPTION
## Proposed Changes

We are making the header sticky for better navigation on the page without always to scroll up again.
To give more structure/hierarchy to the two-level header, we changed the design of the header as well.
What do you all think? See video below.

[sticky.webm](https://github.com/user-attachments/assets/aac7ccda-4813-477c-8042-36a49b423954)

## Checklist

- [x] Added [changelog entry](CHANGELOG.md)
- [x] Added translations for new or changed UI strings
- [x] Executed linter (`npm run lint`)
- [x] Added and executed tests (`npm test`)
