### PR TITLE
Support for rel types edit-form and create-form #321

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,21 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-## [5.0.0] - 2026-07-31
-
 ### Added
 
 - Search filters are now preserved for collection and item searches
 - Opening a collection from the collection search results carries the search criteria over into its item filters
 - An indicator on the item filter toggle shows when the filters were changed but not applied yet
+- Added basic support for the STAC API extensions Transactions (for Items) and Collection Transactions
+  - Adds three new config options: `transactions`, `transactionsRequireLogin` and `transactionsRequirePreflight`
+- Support for external management UIs via `create-form` and `edit-form` links ([RFC 6861](https://www.rfc-editor.org/rfc/rfc6861.html)) in the "Manage" menu
 
 ### Fixed
 
 - The Search page restores the previous results when returning to it
 
-## [5.0.0] - 2026-07-30
+## [5.0.0] - 2026-07-31
 
 ### Added
 
@@ -30,8 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `relationTypes.config.js` to allow configuring link relation types that
   - are specifically STAC and should be used to navigate to and display in STAC Browser
   - should be hidden
-- Added basic support for the STAC API extensions Transactions (for Items) and Collection Transactions
-  - Adds three new config options: `transactions`, `transactionsRequireLogin` and `transactionsRequirePreflight`
 
 ### Changed
 

--- a/config.js
+++ b/config.js
@@ -60,7 +60,7 @@ export default {
   socialSharing: ['email', 'bsky', 'mastodon', 'x'],
   preprocessSTAC: null,
   authConfig: null,
-  transactions: true,
+  transactions: 'auto',
   transactionsRequireLogin: true,
   transactionsRequirePreflight: true,
   crs: {},

--- a/config.schema.json
+++ b/config.schema.json
@@ -160,7 +160,8 @@
       ]
     },
     "transactions": {
-      "type": ["boolean"]
+      "type": ["string"],
+      "enum": ["auto", "external", "internal", "off"]
     },
     "transactionsRequireLogin": {
       "type": ["boolean"]

--- a/docs/options.md
+++ b/docs/options.md
@@ -629,14 +629,35 @@ Defines whether thumbnails are shown in the lists of assets (`true`) or not (`fa
 
 ## Transactions
 
-These options configure how the management of STAC entities via a STAC API (transaction extensions)
-should work in STAC Browser.
+These options configure how the management of STAC entities should work in STAC Browser.
+There are two ways to manage STAC entities:
+
+- **Internal**: The management user interface built into STAC Browser,
+  which uses the STAC API transaction extensions and is only offered if the API
+  advertises the corresponding conformance classes.
+- **External**: A web-based management user interface provided by the server through links with the
+  relation types `create-form` and `edit-form` (see [RFC 6861](https://www.rfc-editor.org/rfc/rfc6861.html))
+  on the current catalog, collection or item.
+  The first link per relation type that has no media type or a HTML media type (`text/html`) is used.
+  The links are shown in the "Manage" menu, open in a new tab, and use the link `title` as the label.
+  STAC Browser does no permission handling for external links; the target server is expected to handle
+  authentication and permissions itself.
 
 ### transactions
 
-Enables (`true`, default) or disables (`false`) the management capabilities globally in STAC Browser.
+Defines which management capabilities are offered in STAC Browser:
+
+- `auto` (default): Prefer external links per action if present, i.e. a `create-form` link replaces the
+  internal "Add Collection" / "Add Item" actions and an `edit-form` link replaces the internal "Edit" action.
+  Otherwise, fall back to the internal user interface if supported by the API.
+  The internal "Delete" action is offered independently as there's no external counterpart.
+- `external`: Only offer the external links, if present.
+- `internal`: Only offer the internal user interface, if supported by the API.
+- `off`: Disable all management capabilities.
 
 ### transactionsRequireLogin
+
+This option only affects the internal management user interface.
 
 By default (option set to `true`), management capabilities will not be shown to unauthenticated users.
 You can disable this check by setting this option to `false` and allow anyone to make transactional requests.
@@ -645,6 +666,8 @@ Disabling this is usually only reasonable for testing purposes or internal STAC 
 This only works in STAC Browser if the server is also configured this way.
 
 ### transactionsRequirePreflight
+
+This option only affects the internal management user interface.
 
 By default (option set to `true`), STAC Browser will check whether a user has permissions to make transactional requests through an `OPTIONS` HTTP request to the same resource that it checks the permissions for.
 STAC Browser reads the permitted methods from the `Allow` response header.

--- a/src/components/StacSource.vue
+++ b/src/components/StacSource.vue
@@ -13,8 +13,20 @@
         <b-dropdown-item v-if="canAddItems" :to="browserPaths.addItem">
           <b-icon-file-plus /> {{ $t('manage.addItem') }}
         </b-dropdown-item>
+        <b-dropdown-item
+          v-if="externalCreateLink" :href="externalCreateLink.getAbsoluteUrl()"
+          target="_blank" rel="noopener noreferrer"
+        >
+          <b-icon-file-plus /> {{ externalCreateLink.title || $t('manage.create') }}
+        </b-dropdown-item>
         <b-dropdown-item v-if="canEdit" :to="browserPaths.edit">
           <b-icon-pencil /> {{ $t('manage.edit') }}
+        </b-dropdown-item>
+        <b-dropdown-item
+          v-if="externalEditLink" :href="externalEditLink.getAbsoluteUrl()"
+          target="_blank" rel="noopener noreferrer"
+        >
+          <b-icon-pencil /> {{ externalEditLink.title || $t('manage.edit') }}
         </b-dropdown-item>
         <b-dropdown-item v-if="canDelete" @click="confirmDelete = true">
           <b-icon-trash /> {{ $t('manage.delete') }}
@@ -129,7 +141,7 @@ export default {
   computed: {
     ...mapState(['data', 'socialSharing', 'url']),
     ...mapGetters(['toBrowserPath', 'collectionLink', 'parentLink', 'rootLink']),
-    ...mapGetters('manager', ['browserPaths', 'canEdit', 'canDelete', 'canManage', 'canAddCollections', 'canAddItems']),
+    ...mapGetters('manager', ['browserPaths', 'canEdit', 'canDelete', 'canManage', 'canAddCollections', 'canAddItems', 'externalCreateLink', 'externalEditLink']),
     stacVersion() {
       return this.data?.stac_version;
     },

--- a/src/locales/en/texts.json
+++ b/src/locales/en/texts.json
@@ -174,6 +174,7 @@
     "addItem": "Add Item",
     "confirmDeleteTitle": "Confirm Deletion",
     "confirmDeleteMessage": "Are you sure you want to delete this STAC resource?",
+    "create": "Create",
     "delete": "Delete",
     "discardDraft": "Discard restored changes",
     "draftRestored": "Unsaved changes from a previous session were restored.",

--- a/src/rels.js
+++ b/src/rels.js
@@ -24,6 +24,8 @@ export const stacBrowserSpecialHandling = [
   'aggregate', // (Irrelevant) Extensions v
   'aggregations',
   'collections-search',
+  'create-form', // Transactions (RFC 6861), shown in the Manage menu v
+  'edit-form',
   'icon', // Other v
   'license',
 ].concat(hierarchical).concat(pagination).concat(queryables).concat(hidden);

--- a/src/store/manager.js
+++ b/src/store/manager.js
@@ -23,6 +23,16 @@ function permissionKey(url) {
   }
 }
 
+// The first link of the given rel type (RFC 6861) that leads to a web page,
+// i.e. has no media type or a HTML media type.
+function getExternalFormLink(getters, rootState, rel) {
+  if (!getters.transactionsAllowExternal || !rootState.data?.isSTAC) {
+    return null;
+  }
+  return rootState.data.getLinksWithRels([rel])
+    .find(link => !link.type || link.type === 'text/html') || null;
+}
+
 export default function getStore(config) {
   return {
     namespaced: true,
@@ -30,6 +40,18 @@ export default function getStore(config) {
       permissions: {}
     },
     getters: {
+      transactionsAllowInternal(state, getters, rootState) {
+        return ['auto', 'internal'].includes(rootState.transactions);
+      },
+      transactionsAllowExternal(state, getters, rootState) {
+        return ['auto', 'external'].includes(rootState.transactions);
+      },
+      externalCreateLink(state, getters, rootState) {
+        return getExternalFormLink(getters, rootState, 'create-form');
+      },
+      externalEditLink(state, getters, rootState) {
+        return getExternalFormLink(getters, rootState, 'edit-form');
+      },
       supportsCollectionTransactions(state, getters, rootState, rootGetters) {
         return rootGetters.supportsConformance(
           TRANSACTION_COLLECTION_CONFORMANCE
@@ -67,7 +89,7 @@ export default function getStore(config) {
         return Boolean(url) && state.permissions[permissionKey(url)] instanceof Loading;
       },
       canManageByUrl: (state, getters, rootState, rootGetters) => (url, method) => {
-        if (!url || !rootState.transactions) {
+        if (!url || !getters.transactionsAllowInternal) {
           return false;
         }
         if (rootState.transactionsRequireLogin && !rootGetters['auth/isLoggedIn']) {
@@ -80,9 +102,16 @@ export default function getStore(config) {
         return true;
       },
       canManage(state, getters, rootState, rootGetters) {
-        return getters.canEdit || getters.canDelete || getters.canAddCollections || getters.canAddItems;
+        return Boolean(
+          getters.canEdit || getters.canDelete || getters.canAddCollections || getters.canAddItems
+          || getters.externalCreateLink || getters.externalEditLink
+        );
       },
       canEdit(state, getters, rootState, rootGetters) {
+        // An external editing UI takes precedence over the internal one
+        if (getters.externalEditLink) {
+          return false;
+        }
         if ((rootGetters.isItem && getters.supportsItemTransactions) || (rootGetters.isCollection && getters.supportsCollectionTransactions)) {
           // We only do full replace (i.e. PUT), no partial replace (i.e. PATCH).
           return getters.canManageByUrl(rootState.url, 'put');
@@ -96,6 +125,10 @@ export default function getStore(config) {
         return false;
       },
       canAddCollections(state, getters, rootState, rootGetters) {
+        // An external creation UI takes precedence over the internal one
+        if (getters.externalCreateLink) {
+          return false;
+        }
         if (!rootState.data?.isCatalogLike || !getters.supportsCollectionTransactions) {
           return false;
         }
@@ -107,6 +140,10 @@ export default function getStore(config) {
         return getters.canManageByUrl(url, 'post');
       },
       canAddItems(state, getters, rootState, rootGetters) {
+        // An external creation UI takes precedence over the internal one
+        if (getters.externalCreateLink) {
+          return false;
+        }
         if (!rootState.data?.isCatalogLike || !getters.supportsItemTransactions) {
           return false;
         }
@@ -140,7 +177,7 @@ export default function getStore(config) {
         const url = options.url ? permissionKey(options.url) : null;
         if (
           !url ||
-          !cx.rootState.transactions ||
+          !cx.getters.transactionsAllowInternal ||
           !cx.rootState.transactionsRequirePreflight ||
           // Don't preflight against servers that don't advertise any transaction
           // support - it would just produce pointless OPTIONS requests.

--- a/tests/e2e/helpers.js
+++ b/tests/e2e/helpers.js
@@ -90,7 +90,7 @@ export async function configureBrowser(page, overrides = {}) {
 */
 export async function enableTransactions(page, overrides = {}) {
   await configureBrowser(page, {
-    transactions: true,
+    transactions: 'auto',
     transactionsRequireLogin: false,
     transactionsRequirePreflight: false,
     ...overrides

--- a/tests/e2e/management.spec.js
+++ b/tests/e2e/management.spec.js
@@ -39,7 +39,7 @@ function createCollectionApi() {
 
 function enablePreflight(page) {
   return configureBrowser(page, {
-    transactions: true,
+    transactions: 'auto',
     transactionsRequireLogin: false,
     transactionsRequirePreflight: true
   });
@@ -152,6 +152,121 @@ test.describe('Management - capability gating', () => {
     await expect(page.getByRole('heading', { name: /add item/i })).toBeVisible();
     await expect(page.locator('.cm-content')).toContainText('"type": "Feature"');
     await expect(page.getByRole('button', { name: /manage/i })).toBeVisible();
+  });
+});
+
+test.describe('Management - external forms', () => {
+  const EDIT_FORM_URL = 'https://editor.example/edit';
+  const CREATE_FORM_URL = 'https://editor.example/create';
+
+  test('an edit-form link replaces the internal Edit action in auto mode', async ({ page, worker }) => {
+    const { api, item } = createItemApi();
+    item.addLink({ href: EDIT_FORM_URL, rel: 'edit-form', title: 'Edit externally' });
+    await api.createServer(worker);
+    await enableTransactions(page);
+
+    await page.goto(item.getBrowserPath());
+    await waitForBrowserReady(page);
+
+    await openManageMenu(page);
+    const external = page.getByRole('menuitem', { name: 'Edit externally' });
+    await expect(external).toBeVisible();
+    await expect(external).toHaveAttribute('href', EDIT_FORM_URL);
+    await expect(external).toHaveAttribute('target', '_blank');
+    await expect(page.getByRole('menuitem', { name: 'Edit', exact: true })).toHaveCount(0);
+    // Delete has no external counterpart and stays available
+    await expect(page.getByRole('menuitem', { name: 'Delete' })).toBeVisible();
+  });
+
+  test('a create-form link replaces the internal Add actions in auto mode', async ({ page, worker }) => {
+    const api = API.minimalApi().addItemTransactionsExtension().addCollectionTransactionsExtension();
+    api.addCollection('collection').setMetadata({ title: 'Test Collection' });
+    api.root.addLink({ href: CREATE_FORM_URL, rel: 'create-form', title: 'Create externally' });
+    await api.createServer(worker);
+    await enableTransactions(page);
+
+    await page.goto(api.root.getBrowserPath());
+    await waitForBrowserReady(page);
+
+    await openManageMenu(page);
+    await expect(page.getByRole('menuitem', { name: 'Create externally' })).toBeVisible();
+    await expect(page.getByRole('menuitem', { name: 'Add Collection' })).toHaveCount(0);
+    await expect(page.getByRole('menuitem', { name: 'Add Item' })).toHaveCount(0);
+  });
+
+  test('external mode shows links without login and hides the internal actions', async ({ page, worker }) => {
+    const { api, item } = createItemApi();
+    item.addLink({ href: EDIT_FORM_URL, rel: 'edit-form', title: 'Edit externally' });
+    await api.createServer(worker);
+    // Login and preflight requirements stay at their defaults (true),
+    // they must not affect external links
+    await configureBrowser(page, { transactions: 'external' });
+
+    await page.goto(item.getBrowserPath());
+    await waitForBrowserReady(page);
+
+    await openManageMenu(page);
+    await expect(page.getByRole('menuitem', { name: 'Edit externally' })).toBeVisible();
+    await expect(page.getByRole('menuitem', { name: 'Edit', exact: true })).toHaveCount(0);
+    await expect(page.getByRole('menuitem', { name: 'Delete' })).toHaveCount(0);
+  });
+
+  test('external mode without form links shows no Manage control', async ({ page, worker }) => {
+    const { api, item } = createItemApi();
+    await api.createServer(worker);
+    await configureBrowser(page, { transactions: 'external' });
+
+    await page.goto(item.getBrowserPath());
+    await waitForBrowserReady(page);
+    await expect(page.getByRole('heading', { name: new RegExp(item.data.id, 'i') })).toBeVisible();
+
+    await expect(page.getByRole('button', { name: /manage/i })).toHaveCount(0);
+  });
+
+  test('internal mode ignores form links', async ({ page, worker }) => {
+    const { api, item } = createItemApi();
+    item.addLink({ href: EDIT_FORM_URL, rel: 'edit-form', title: 'Edit externally' });
+    await api.createServer(worker);
+    await enableTransactions(page, { transactions: 'internal' });
+
+    await page.goto(item.getBrowserPath());
+    await waitForBrowserReady(page);
+
+    await openManageMenu(page);
+    await expect(page.getByRole('menuitem', { name: 'Edit', exact: true })).toBeVisible();
+    await expect(page.getByRole('menuitem', { name: 'Edit externally' })).toHaveCount(0);
+  });
+
+  test('off disables all management capabilities', async ({ page, worker }) => {
+    const { api, item } = createItemApi();
+    item.addLink({ href: EDIT_FORM_URL, rel: 'edit-form', title: 'Edit externally' });
+    await api.createServer(worker);
+    await enableTransactions(page, { transactions: 'off' });
+
+    await page.goto(item.getBrowserPath());
+    await waitForBrowserReady(page);
+    await expect(page.getByRole('heading', { name: new RegExp(item.data.id, 'i') })).toBeVisible();
+
+    await expect(page.getByRole('button', { name: /manage/i })).toHaveCount(0);
+  });
+
+  test('only the first form link with a suitable media type is used', async ({ page, worker }) => {
+    const { api, item } = createItemApi();
+    item.addLink({ href: EDIT_FORM_URL + '.json', rel: 'edit-form', title: 'Machine-readable', type: 'application/json' });
+    item.addLink({ href: EDIT_FORM_URL, rel: 'edit-form', title: 'Edit externally', type: 'text/html' });
+    item.addLink({ href: EDIT_FORM_URL + '/2', rel: 'edit-form', title: 'Second editor' });
+    await api.createServer(worker);
+    await enableTransactions(page);
+
+    await page.goto(item.getBrowserPath());
+    await waitForBrowserReady(page);
+
+    await openManageMenu(page);
+    const external = page.getByRole('menuitem', { name: 'Edit externally' });
+    await expect(external).toBeVisible();
+    await expect(external).toHaveAttribute('href', EDIT_FORM_URL);
+    await expect(page.getByRole('menuitem', { name: 'Machine-readable' })).toHaveCount(0);
+    await expect(page.getByRole('menuitem', { name: 'Second editor' })).toHaveCount(0);
   });
 });
 


### PR DESCRIPTION
## Proposed Changes

Closes #321.

With an API that adds the link if you have proper permissions, you should be able to wire up e.g. stac-manager as external editor. cc @j08lue

## Checklist

- [x] Added [changelog entry](CHANGELOG.md)
- [x] Added translations for new or changed UI strings
- [x] Executed linter (`npm run lint`)
- [x] Added and executed tests (`npm test`)
