### PR TITLE
Add getStacLayerOptions config option to customize ol-stac layer options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Items can be shown in a list view in addition to the card view, with the same view toggle buttons as for catalogs and collections
 - Search Example Code is now also available for curl and Go
 - The map can display more Zarr datasets
-- New config option `getStacLayerOptions` to customize the ol-stac layer options per STAC object, e.g. to style GeoTIFF/GeoZarr layers
+- New config option `getStacLayerOptions` to customize the options of the individual map layers created for STAC assets and links, e.g. to style GeoTIFF/GeoZarr layers
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Items can be shown in a list view in addition to the card view, with the same view toggle buttons as for catalogs and collections
 - Search Example Code is now also available for curl and Go
 - The map can display more Zarr datasets
+- New config option `getStacLayerOptions` to customize the ol-stac layer options per STAC object, e.g. to style GeoTIFF/GeoZarr layers
 
 ### Changed
 

--- a/config.js
+++ b/config.js
@@ -41,6 +41,7 @@ export default {
   maxDisplayPixels: null,
   buildTileUrlTemplate: null,
   getMapSourceOptions: null,
+  getStacLayerOptions: null,
   pathPrefix: "/",
   historyMode: "history",
   cardViewMode: "cards",

--- a/config.schema.json
+++ b/config.schema.json
@@ -84,6 +84,12 @@
       "noCLI": true,
       "noEnv": true
     },
+    "getStacLayerOptions": {
+      "type": ["null"],
+      "format": "function",
+      "noCLI": true,
+      "noEnv": true
+    },
     "pathPrefix": {
       "type": ["string"]
     },

--- a/docs/options.md
+++ b/docs/options.md
@@ -560,26 +560,34 @@ getSourceOptions: async (type, options) => {
 
 ### getStacLayerOptions
 
-A function that can customize the [ol-stac `STACLayer` options](https://m-mohr.github.io/ol-stac/en/latest/apidoc/module-ol-stac_layer_STAC-STACLayer.html)
-before the layer is created for a map. It is called with the assembled options and the STAC object
-that is going to be shown on the map, and must (synchronously) return the options to use.
+A function that can customize the options of the individual OpenLayers layers that
+[ol-stac](https://m-mohr.github.io/ol-stac/) creates for the assets and links of a STAC object.
+It is passed through to the [`getLayerOptions` option of the ol-stac `STACLayer`](https://m-mohr.github.io/ol-stac/en/latest/apidoc/module-ol-stac_layer_STAC-STACLayer.html)
+and is called right before each individual layer is created:
 
 ```js
-getStacLayerOptions(options, stac) => options
+getStacLayerOptions(type, options, reference) => options | Promise<options>
 ```
 
-This allows to customize the map rendering per catalog, collection or item, for example to
-provide a [style](https://openlayers.org/en/latest/apidoc/module-ol_layer_WebGLTile.html#~Style)
+- `type` is the [layer type](https://m-mohr.github.io/ol-stac/en/latest/apidoc/module-ol-stac_layer_type-LayerType.html)
+  that is going to be created (compare with `String(type)`, e.g. `'WebGLTile'` for GeoTIFF and GeoZarr layers).
+- `options` are the assembled layer options.
+- `reference` is the STAC Asset or Link the layer is created for.
+
+The function can be asynchronous, e.g. to load a style definition that is referenced in the
+STAC metadata, which only delays the creation of the individual layer.
+
+This allows to customize the map rendering per asset or link, for example to provide a
+[style](https://openlayers.org/en/latest/apidoc/module-ol_layer_WebGLTile.js.html#~Style)
 for GeoTIFF or GeoZarr layers (e.g. rescaling single-band data that would otherwise render
-without contrast), or to enforce rendering specific web map links by setting `displayWebMapLink`
-to an array.
+without contrast).
 
 For example, the following code would apply a grayscale style to all GeoZarr/GeoTIFF layers
 of a specific collection:
 
 ```js
-getStacLayerOptions: (options, stac) => {
-  if (stac.collection === 'my-datacubes') {
+getStacLayerOptions: (type, options, reference) => {
+  if (String(type) === 'WebGLTile' && reference.getContext()?.collection === 'my-datacubes') {
     options.style = {
       color: ['array', ['/', ['band', 1], 4000], ['/', ['band', 1], 4000], ['/', ['band', 1], 4000], 1]
     };
@@ -587,8 +595,6 @@ getStacLayerOptions: (options, stac) => {
   return options;
 }
 ```
-
-The `data`, `children` and `assets` options are set by STAC Browser and should not be replaced.
 
 ## User Interface
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -82,6 +82,7 @@ The override order for the configuration is:
   - [maxDisplayPixels](#maxdisplaypixels)
   - [crs](#crs)
   - [getMapSourceOptions](#getmapsourceoptions)
+  - [getStacLayerOptions](#getstaclayeroptions)
 - [User Interface](#user-interface)
   - [enforcedColorMode](#enforcedcolormode)
   - [cardViewMode](#cardviewmode)
@@ -556,6 +557,38 @@ getSourceOptions: async (type, options) => {
   return options;
 }
 ```
+
+### getStacLayerOptions
+
+A function that can customize the [ol-stac `STACLayer` options](https://m-mohr.github.io/ol-stac/en/latest/apidoc/module-ol-stac_layer_STAC-STACLayer.html)
+before the layer is created for a map. It is called with the assembled options and the STAC object
+that is going to be shown on the map, and must (synchronously) return the options to use.
+
+```js
+getStacLayerOptions(options, stac) => options
+```
+
+This allows to customize the map rendering per catalog, collection or item, for example to
+provide a [style](https://openlayers.org/en/latest/apidoc/module-ol_layer_WebGLTile.html#~Style)
+for GeoTIFF or GeoZarr layers (e.g. rescaling single-band data that would otherwise render
+without contrast), or to enforce rendering specific web map links by setting `displayWebMapLink`
+to an array.
+
+For example, the following code would apply a grayscale style to all GeoZarr/GeoTIFF layers
+of a specific collection:
+
+```js
+getStacLayerOptions: (options, stac) => {
+  if (stac.collection === 'my-datacubes') {
+    options.style = {
+      color: ['array', ['/', ['band', 1], 4000], ['/', ['band', 1], 4000], ['/', ['band', 1], 4000], 1]
+    };
+  }
+  return options;
+}
+```
+
+The `data`, `children` and `assets` options are set by STAC Browser and should not be replaced.
 
 ## User Interface
 

--- a/src/components/MapView.vue
+++ b/src/components/MapView.vue
@@ -200,6 +200,9 @@ export default {
         disableMigration: true,
         childrenOptions: this.childrenOptions
       });
+      if (typeof this.getStacLayerOptions === 'function') {
+        options = this.getStacLayerOptions(options, this.stac) || options;
+      }
       if (this.ignoreDisplayLimit) {
         options.maxDisplayPixels = Infinity;
       }

--- a/src/components/MapView.vue
+++ b/src/components/MapView.vue
@@ -190,7 +190,7 @@ export default {
       }
     },
     addStacLayer() {
-      let options = Object.assign({}, this.stacLayerOptions, {
+      const options = Object.assign({}, this.stacLayerOptions, {
         // Don't set the URL here, as it is already set in the STAC object and is read-only.
         // url: this.stac.getAbsoluteUrl(),
         data: this.stac,
@@ -200,9 +200,6 @@ export default {
         disableMigration: true,
         childrenOptions: this.childrenOptions
       });
-      if (typeof this.getStacLayerOptions === 'function') {
-        options = this.getStacLayerOptions(options, this.stac) || options;
-      }
       if (this.ignoreDisplayLimit) {
         options.maxDisplayPixels = Infinity;
       }

--- a/src/components/maps/MapMixin.js
+++ b/src/components/maps/MapMixin.js
@@ -35,6 +35,7 @@ export default {
         displayGeoTiffByDefault: this.displayGeoTiffByDefault,
         useTileLayerAsFallback: this.useTileLayerAsFallback,
         getSourceOptions: this.getMapSourceOptions,
+        getLayerOptions: this.getStacLayerOptions,
         getRequestHeaders: this.getRequestHeadersForStacLayer,
         // Adds the configured query parameters (incl. query-parameter
         // credentials) to the URLs requested by ol-stac

--- a/src/components/maps/MapMixin.js
+++ b/src/components/maps/MapMixin.js
@@ -24,7 +24,7 @@ register(proj4); // required to support source reprojection
 
 export default {
   computed: {
-    ...mapState(['buildTileUrlTemplate', 'colorMode', 'crossOriginMedia', 'displayGeoTiffByDefault', 'displayPreview', 'displayOverview', 'getMapSourceOptions', 'maxDisplayPixels', 'useTileLayerAsFallback', 'uiLanguage']),
+    ...mapState(['buildTileUrlTemplate', 'colorMode', 'crossOriginMedia', 'displayGeoTiffByDefault', 'displayPreview', 'displayOverview', 'getMapSourceOptions', 'getStacLayerOptions', 'maxDisplayPixels', 'useTileLayerAsFallback', 'uiLanguage']),
     ...mapGetters(['getRequestUrl']),
     stacLayerOptions() {
       const options = {

--- a/tests/e2e/map-layer-options.spec.js
+++ b/tests/e2e/map-layer-options.spec.js
@@ -1,0 +1,94 @@
+/**
+ * getStacLayerOptions config option tests.
+ *
+ * Verifies that the `getStacLayerOptions` function from the config is called
+ * with the assembled ol-stac layer options and the STAC object shown on the
+ * map, and that the options it returns are the ones used to create the layer.
+ *
+ * The function is injected at runtime through `window.STAC_BROWSER_CONFIG`
+ * (see src/merged-config.js), which is how deployments provide function-valued
+ * config options.
+ */
+import { test, expect } from './fixtures.js';
+import { waitForBrowserReady, waitForMapReady } from './helpers.js';
+import StaticCatalog from '../fixtures/instances/static.js';
+
+function createItem() {
+  const catalog = new StaticCatalog({ url: 'https://stac.example/catalog.json' });
+  const item = catalog.addItem({ url: 'https://stac.example/item.json', template: 'minimal' })
+    .setMetadata({ title: 'Layer Options Item', datetime: '2025-01-01T00:00:00Z' });
+  item.data.bbox = [172, -42, 175, -39];
+  item.data.geometry = {
+    type: 'Polygon',
+    coordinates: [[
+      [172, -42],
+      [175, -42],
+      [175, -39],
+      [172, -39],
+      [172, -42],
+    ]],
+  };
+  return { catalog, item };
+}
+
+test.describe('getStacLayerOptions', () => {
+  test('is called with the layer options and STAC object, and its result is used', async ({ page, worker }) => {
+    const { catalog, item } = createItem();
+    await catalog.createServer(worker);
+
+    await page.addInitScript(() => {
+      window.__stacLayerHook = { calls: 0, stacIds: [], hadData: [] };
+      window.STAC_BROWSER_CONFIG = {
+        getStacLayerOptions: (options, stac) => {
+          window.__stacLayerHook.calls++;
+          window.__stacLayerHook.stacIds.push(stac?.id ?? null);
+          window.__stacLayerHook.hadData.push(options?.data === stac);
+          // `properties` is passed through to the OpenLayers layer, so the
+          // test can verify that the returned options were actually used.
+          return { ...options, properties: { e2eLayerOptionsApplied: true } };
+        },
+      };
+    });
+
+    await page.goto(item.getBrowserPath());
+    await waitForBrowserReady(page);
+    await waitForMapReady(page);
+
+    // The hook was called with the STAC object of the page and the assembled options.
+    await expect
+      .poll(() => page.evaluate(() => window.__stacLayerHook.calls), { timeout: 15000 })
+      .toBeGreaterThan(0);
+    const hook = await page.evaluate(() => window.__stacLayerHook);
+    expect(hook.stacIds).toContain(item.data.id);
+    expect(hook.hadData).toContain(true);
+
+    // The returned options were used to create the layer: the injected
+    // property is readable on the ol-stac layer. The OL map isn't exposed to
+    // the DOM, so locate it via the MapView component instance (see
+    // getMapState in helpers.js).
+    await expect
+      .poll(() => page.evaluate(() => {
+        let el = document.querySelector('.map-container .map') || document.querySelector('.map');
+        let map = null;
+        while (el) {
+          const inst = el.__vueParentComponent;
+          let candidate;
+          try {
+            candidate = inst?.proxy?.map ?? inst?.ctx?.map;
+          } catch {
+            candidate = null;
+          }
+          if (candidate && typeof candidate.getView === 'function') {
+            map = candidate;
+            break;
+          }
+          el = el.parentElement;
+        }
+        if (!map) {
+          return false;
+        }
+        return map.getLayers().getArray().some((layer) => layer.get && layer.get('e2eLayerOptionsApplied') === true);
+      }), { timeout: 15000 })
+      .toBe(true);
+  });
+});

--- a/tests/e2e/map-layer-options.spec.js
+++ b/tests/e2e/map-layer-options.spec.js
@@ -1,9 +1,11 @@
 /**
  * getStacLayerOptions config option tests.
  *
- * Verifies that the `getStacLayerOptions` function from the config is called
- * with the assembled ol-stac layer options and the STAC object shown on the
- * map, and that the options it returns are the ones used to create the layer.
+ * Verifies that the `getStacLayerOptions` function from the config is passed
+ * through to ol-stac's `getLayerOptions` option: it is called with the layer
+ * type, the assembled layer options and the STAC Asset or Link right before
+ * each individual layer is created, and the options it returns (possibly
+ * asynchronously) are the ones used to create the layer.
  *
  * The function is injected at runtime through `window.STAC_BROWSER_CONFIG`
  * (see src/merged-config.js), which is how deployments provide function-valued
@@ -28,24 +30,35 @@ function createItem() {
       [172, -42],
     ]],
   };
+  // The item has no assets, so this web map link is rendered as a tile layer
+  // and the getStacLayerOptions hook is called for it.
+  item.addLink({
+    rel: 'xyz',
+    href: 'https://tiles.example/{z}/{x}/{y}.png',
+    id: 'e2e-tiles',
+    type: 'image/png',
+  });
   return { catalog, item };
 }
 
 test.describe('getStacLayerOptions', () => {
-  test('is called with the layer options and STAC object, and its result is used', async ({ page, worker }) => {
+  test('is passed through to ol-stac and applied to the created layers', async ({ page, worker }) => {
     const { catalog, item } = createItem();
     await catalog.createServer(worker);
 
     await page.addInitScript(() => {
-      window.__stacLayerHook = { calls: 0, stacIds: [], hadData: [] };
+      window.__stacLayerHook = { calls: [] };
       window.STAC_BROWSER_CONFIG = {
-        getStacLayerOptions: (options, stac) => {
-          window.__stacLayerHook.calls++;
-          window.__stacLayerHook.stacIds.push(stac?.id ?? null);
-          window.__stacLayerHook.hadData.push(options?.data === stac);
+        getStacLayerOptions: (type, options, reference) => {
+          window.__stacLayerHook.calls.push({
+            type: String(type),
+            rel: reference?.rel ?? null,
+            hasSource: Boolean(options?.source),
+          });
+          // Returned as a promise on purpose: ol-stac must await it.
           // `properties` is passed through to the OpenLayers layer, so the
           // test can verify that the returned options were actually used.
-          return { ...options, properties: { e2eLayerOptionsApplied: true } };
+          return Promise.resolve({ ...options, properties: { e2eLayerOptionsApplied: true } });
         },
       };
     });
@@ -54,18 +67,17 @@ test.describe('getStacLayerOptions', () => {
     await waitForBrowserReady(page);
     await waitForMapReady(page);
 
-    // The hook was called with the STAC object of the page and the assembled options.
+    // The hook was called for the tile layer created for the web map link.
     await expect
-      .poll(() => page.evaluate(() => window.__stacLayerHook.calls), { timeout: 15000 })
+      .poll(() => page.evaluate(() => window.__stacLayerHook.calls.length), { timeout: 15000 })
       .toBeGreaterThan(0);
     const hook = await page.evaluate(() => window.__stacLayerHook);
-    expect(hook.stacIds).toContain(item.data.id);
-    expect(hook.hadData).toContain(true);
+    expect(hook.calls).toContainEqual({ type: 'Tile', rel: 'xyz', hasSource: true });
 
     // The returned options were used to create the layer: the injected
-    // property is readable on the ol-stac layer. The OL map isn't exposed to
-    // the DOM, so locate it via the MapView component instance (see
-    // getMapState in helpers.js).
+    // property is readable on the layer nested inside the ol-stac layer
+    // group. The OL map isn't exposed to the DOM, so locate it via the
+    // MapView component instance (see getMapState in helpers.js).
     await expect
       .poll(() => page.evaluate(() => {
         let el = document.querySelector('.map-container .map') || document.querySelector('.map');
@@ -87,7 +99,10 @@ test.describe('getStacLayerOptions', () => {
         if (!map) {
           return false;
         }
-        return map.getLayers().getArray().some((layer) => layer.get && layer.get('e2eLayerOptionsApplied') === true);
+        // Flatten layer groups (the ol-stac layer is a LayerGroup).
+        const layers = map.getLayers().getArray()
+          .flatMap((layer) => (layer.getLayersArray ? layer.getLayersArray() : [layer]));
+        return layers.some((layer) => layer.get && layer.get('e2eLayerOptionsApplied') === true);
       }), { timeout: 15000 })
       .toBe(true);
   });


### PR DESCRIPTION
## Description

New optional config function `getStacLayerOptions(type, options, reference) => options | Promise<options>`, passed through to the `getLayerOptions` option that was added to ol-stac in moregeo-it/ol-stac#44 (as suggested in the review below). ol-stac calls it with the layer type, the assembled layer options and the STAC Asset or Link right before each individual layer is created. The function may be asynchronous (e.g. to load a style file referenced in the STAC metadata), which only delays the creation of that individual layer — the footprint/bbox display is not affected.

Example use cases this unlocks without STAC Browser having to own any rendering policy:

- Provide a WebGLTile `style` for GeoTIFF/GeoZarr layers — e.g. single-band datacubes with large value ranges currently render without contrast under the default style (see the [ol-stac NDVI example](https://github.com/moregeo-it/ol-stac/blob/main/examples/stac-item-zarr-ndvi.js) for what this enables).
- Customize the layers created for web map links (PMTiles/XYZ/…), preview images or GeoJSON assets per asset/link.

Related: #254

## Status

**Blocked on an ol-stac release containing `getLayerOptions`** (merged in moregeo-it/ol-stac#44, not yet published — latest is 1.5.1). Once released, the only remaining change is the `package.json`/lockfile bump; until then the `map-layer-options` e2e test fails in CI because the registry version ignores the option. Verified locally against a package built from ol-stac `main` (`ffd83fa`): the new e2e test and the full suite (183 tests) pass.

## PR Checklist

- [x] I have added my changes to the CHANGELOG
- [x] Documentation added in `docs/options.md`