### PR TITLE
Fix Collection list (filters, odering) in Collection Search #955

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The Search page restores the previous results when returning to it
 - Temporal extents were incomplete in non-English languages
+- Don't show inline sort and filter options in Collection Search
+- Preserve sort in Collection Search
 
 ## [5.0.0] - 2026-07-31
 

--- a/src/components/Catalogs.vue
+++ b/src/components/Catalogs.vue
@@ -3,10 +3,10 @@
     <header>
       <h2 class="title me-2">{{ displayTitle }}</h2>
       <b-badge v-if="!hideCount && catalogCount !== null" pill variant="secondary" class="me-4">{{ catalogCount }}</b-badge>
-      <ViewButtons v-if="!hideControls" class="me-2" v-model="view" />
-      <SortButtons v-if="!hideControls && isComplete && catalogs.length > 1" v-model="sort.direction" />
+      <ViewButtons v-if="!enforceView && !enforceCards" class="me-2" v-model="view" />
+      <SortButtons v-if="allowSorting" v-model="sort.direction" />
     </header>
-    <section v-if="!hideControls && ((isComplete && catalogs.length > 1) || canSearchFreeText)" class="catalog-filter mb-2">
+    <section v-if="showControls && ((isComplete && catalogs.length > 1) || canSearchFreeText)" class="catalog-filter mb-2">
       <template v-if="canSearchFreeText">
         <multiselect
           multiple taggable @tag="addSearchTerm"
@@ -96,15 +96,11 @@ export default defineComponent({
       default: null,
       validator: value => value === null || ['list', 'cards'].includes(value)
     },
-    hideControls: {
+    showControls: {
       type: Boolean,
       default: false
     },
     hideCount: {
-      type: Boolean,
-      default: false
-    },
-    preserveOrder: {
       type: Boolean,
       default: false
     },
@@ -197,6 +193,9 @@ export default defineComponent({
       }
       return this.allCatalogs.every(obj => obj.isSTAC);
     },
+    allowSorting() {
+      return this.showControls && this.isComplete && this.catalogs.length > 1;
+    },
     filterPlaceholder() {
       return this.isComplete ? this.$t('catalogs.filterByTitleAndMore') : this.$t('catalogs.filterByTitle');
     },
@@ -243,8 +242,7 @@ export default defineComponent({
           return true;
         });
       }
-      // Sort
-      if (!this.preserveOrder && !this.hasMore && !this.apiFilters.sortby && this.sort.direction !== 0) {
+      if (this.allowSorting && !this.apiFilters.sortby && this.sort.direction !== 0) {
         catalogs = sortStac(catalogs, this.sort, this.uiLanguage);
       }
       return catalogs;

--- a/src/components/Catalogs.vue
+++ b/src/components/Catalogs.vue
@@ -180,12 +180,8 @@ export default defineComponent({
       if (this.title !== null) {
         return this.title;
       }
-      else if (this.collectionsOnly) {
-        return this.$t('stacCollection', this.catalogs.length );
-      }
-      else {
-        return this.$t('stacCatalog', this.catalogs.length );
-      }
+      let key = (this.collectionsOnly || this.catalogs.every(catalog => catalog.isCollection)) ? 'stacCollection' : 'stacCatalog';
+      return this.$t(key, this.catalogs.length );
     },
     isComplete() {
       if (this.hasMore || this.showPagination) {

--- a/src/components/MapView.vue
+++ b/src/components/MapView.vue
@@ -14,7 +14,7 @@
     >
       <section class="popover-children">
         <Items v-if="selection.type === 'items'" :stac="stac" :items="selection.children" />
-        <Catalogs v-else-if="selection.type === 'collections'" collectionsOnly enforceCards hideControls :stac="stac" :catalogs="selection.children" />
+        <Catalogs v-else-if="selection.type === 'collections'" collectionsOnly enforceCards :stac="stac" :catalogs="selection.children" />
         <Features v-else :features="selection.children" />
       </section>
       <div class="text-center">

--- a/src/views/Catalog.vue
+++ b/src/views/Catalog.vue
@@ -47,6 +47,7 @@
         <WidgetHook id="view-catalog-catalogs-start" />
         <Catalogs
           :apiSearch="hasApiCollections" :catalogs="catalogs" :hasMore="hasMore"
+          showControls
           @load-more="loadMoreCollections" @search="searchCollections"
           :loading="Boolean(loadingCollections) || loadingNextCollectionsPage" :loadingMore="loadingCollections === 'more' || loadingNextCollectionsPage"
         />

--- a/src/widgets/Featured.vue
+++ b/src/widgets/Featured.vue
@@ -2,7 +2,7 @@
   <Catalogs
     v-if="resolvedEntities.length > 0" class="featured"
     :catalogs="resolvedEntities" :title="heading" :enforceView="view"
-    hideControls hideCount preserveOrder
+    hideCount
   />
 </template>
 

--- a/tests/e2e/search-workflows.spec.js
+++ b/tests/e2e/search-workflows.spec.js
@@ -395,3 +395,53 @@ test.describe('Search filter carry-over workflows', () => {
     });
   });
 });
+
+// The collection search results are the server's answer to a query, so the
+// list must be shown as returned: no client-side re-sorting of the results and
+// no redundant client-side filter bar over them (#955).
+test.describe('Collection search results are server-authoritative (#955)', () => {
+  let api;
+  let BROWSER_PATH;
+
+  test.beforeEach(async ({ worker }) => {
+    api = API.minimalApi({}, { defaultLimit: 10, freeTextSearchEnabled: true });
+
+    // Added in a deliberately non-alphabetical order so the order returned by
+    // the server (Zulu before Alpha) differs from the default title sort, which
+    // would otherwise reorder the results alphabetically.
+    api.addCollection('zulu').setMetadata({ title: 'Zulu Collection' });
+    api.addCollection('alpha').setMetadata({ title: 'Alpha Collection' });
+
+    api.addCollectionsExtension()
+      .addItemsExtension()
+      .addSearchExtension();
+    api.root.addConformsTo('https://api.stacspec.org/v1.0.0/collection-search');
+    api.root.addConformsTo('https://api.stacspec.org/v1.0.0/collection-search#free-text');
+
+    await api.createServer(worker);
+    BROWSER_PATH = api.root.getBrowserPath();
+  });
+
+  test('results preserve the API order and hide the client-side filter bar', async ({ page }) => {
+    await goToCollectionSearchTab(page, BROWSER_PATH);
+
+    await test.step('Execute a collection search', async () => {
+      await page.getByRole('button', { name: /submit/i }).click();
+      await waitForBrowserReady(page);
+    });
+
+    await test.step('The results keep the order returned by the API', async () => {
+      const cards = page.locator('.catalogs .card-grid > *');
+      await expect(cards).toHaveCount(2);
+      await expect(cards.first()).toContainText('Zulu Collection');
+    });
+
+    await test.step('The redundant client-side filter bar is not shown', async () => {
+      await expect(page.locator('.catalogs .catalog-filter')).toHaveCount(0);
+    });
+
+    await test.step('The list/cards view toggle stays available', async () => {
+      await expect(page.locator('.catalogs header').getByRole('button', { name: /list/i })).toBeVisible();
+    });
+  });
+});


### PR DESCRIPTION
Closes #955

## Proposed Changes

- Don't show inline sort and filter options in Collection Search
- Preserve sort in Collection Search

## Checklist

- [x] Added [changelog entry](CHANGELOG.md)
- [x] Added translations for new or changed UI strings
- [x] Executed linter (`npm run lint`)
- [x] Added and executed tests (`npm test`)
