### PR TITLE
Fix config.schema.json handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The Docker entrypoint and Vite config now support both forms of the JSON Schema `type` keyword (a string or an array of strings), fixing a `jq` error when setting `SB_footerLinks` via environment variables
 - `apiCatalogPriority: "childs"` doesn't hide collection items in the sidebar anymore
 - The conformance classes of the configured catalog are no longer applied to external content,
   e.g. sorting and filtering are no longer offered for (and sent to) external APIs that may not support them

--- a/config.schema.json
+++ b/config.schema.json
@@ -1,8 +1,6 @@
 {
   "$comment": "Defines a JSON Schema for the config file. Note that JS functions are specified as type 'null' with format 'function'.",
-  "type": [
-    "object"
-  ],
+  "type": "object",
   "properties": {
     "catalogUrl": {
       "type": ["string", "null"],
@@ -19,34 +17,34 @@
       "format": "uri"
     },
     "allowExternalAccess": {
-      "type": ["boolean"]
+      "type": "boolean"
     },
     "allowedDomains": {
-      "type": ["array"],
+      "type": "array",
       "items": {
-        "type": ["string"]
+        "type": "string"
       }
     },
     "enforcedColorMode": {
-      "type": ["string"],
+      "type": "string",
       "enum": ["light", "dark", "auto"]
     },
     "detectLocaleFromBrowser": {
-      "type": ["boolean"]
+      "type": "boolean"
     },
     "storeLocale": {
-      "type": ["boolean"]
+      "type": "boolean"
     },
     "locale": {
-      "type": ["string"]
+      "type": "string"
     },
     "fallbackLocale": {
-      "type": ["string"]
+      "type": "string"
     },
     "supportedLocales": {
-      "type": ["array"],
+      "type": "array",
       "items": {
-        "type": ["string"]
+        "type": "string"
       }
     },
     "apiCatalogPriority": {
@@ -54,56 +52,56 @@
       "enum": ["collections", "childs", null]
     },
     "useTileLayerAsFallback": {
-      "type": ["boolean"]
+      "type": "boolean"
     },
     "displayGeoTiffByDefault": {
-      "type": ["boolean"]
+      "type": "boolean"
     },
     "displayPreview": {
-      "type": ["boolean"]
+      "type": "boolean"
     },
     "displayOverview": {
-      "type": ["boolean"]
+      "type": "boolean"
     },
     "displayOverviewsForChildren": {
-      "type": ["boolean"]
+      "type": "boolean"
     },
     "maxDisplayPixels": {
       "type": ["number", "null"],
       "minimum": 1
     },
     "buildTileUrlTemplate": {
-      "type": ["null"],
+      "type": "null",
       "format": "function",
       "noCLI": true,
       "noEnv": true
     },
     "getMapSourceOptions": {
-      "type": ["null"],
+      "type": "null",
       "format": "function",
       "noCLI": true,
       "noEnv": true
     },
     "getStacLayerOptions": {
-      "type": ["null"],
+      "type": "null",
       "format": "function",
       "noCLI": true,
       "noEnv": true
     },
     "pathPrefix": {
-      "type": ["string"]
+      "type": "string"
     },
     "historyMode": {
-      "type": ["string"],
+      "type": "string",
       "enum": ["history", "hash"],
       "buildOnly": true
     },
     "cardViewMode": {
-      "type": ["string"],
+      "type": "string",
       "enum": ["list", "cards"]
     },
     "showFavorites": {
-      "type": ["boolean"]
+      "type": "boolean"
     },
     "defaultItemSort": {
       "type": ["string", "null"]
@@ -112,10 +110,10 @@
       "type": ["string", "null"]
     },
     "showThumbnailsAsAssets": {
-      "type": ["boolean"]
+      "type": "boolean"
     },
     "searchResultsPerPage": {
-      "type": ["integer"],
+      "type": "integer",
       "minimum": 1
     },
     "itemsPerPage": {
@@ -127,7 +125,7 @@
       "minimum": 1
     },
     "maxEntriesPerPage": {
-      "type": ["integer"],
+      "type": "integer",
       "minimum": 1
     },
     "defaultThumbnailSize": {
@@ -135,7 +133,7 @@
       "minItems": 2,
       "maxItems": 2,
       "items": {
-        "type": ["number"]
+        "type": "number"
       }
     },
     "crossOriginMedia": {
@@ -143,15 +141,15 @@
       "enum": ["anonymous", "use-credentials", "", null]
     },
     "requestHeaders": {
-      "type": ["object"]
+      "type": "object"
     },
     "requestQueryParameters": {
-      "type": ["object"]
+      "type": "object"
     },
     "socialSharing": {
-      "type": ["array"],
+      "type": "array",
       "items": {
-        "type": ["string"]
+        "type": "string"
       }
     },
     "preferredAssets": {
@@ -159,13 +157,13 @@
       "description": "Preferred asset selection strategy: false (show main asset), true (prefer HTTP/S), or asset key name (string)"
     },
     "preprocessSTAC": {
-      "type": ["null"],
+      "type": "null",
       "format": "function",
       "noCLI": true,
       "noEnv": true
     },
     "authConfig": {
-      "type": ["object"],
+      "type": "object",
       "allOf": [
         {
           "$ref": "https://stac-extensions.github.io/authentication/v1.1.0/schema.json"
@@ -173,17 +171,17 @@
       ]
     },
     "transactions": {
-      "type": ["string"],
+      "type": "string",
       "enum": ["auto", "external", "internal", "off"]
     },
     "transactionsRequireLogin": {
-      "type": ["boolean"]
+      "type": "boolean"
     },
     "transactionsRequirePreflight": {
-      "type": ["boolean"]
+      "type": "boolean"
     },
     "crs": {
-      "type": ["object"]
+      "type": "object"
     },
     "footerLinks": {
       "type": ["array", "null"],

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -96,6 +96,13 @@ config_schema=$(cat /etc/nginx/conf.d/config.schema.json)
 runtime_config_tmp=/usr/share/nginx/html/runtime-config.js.tmp
 runtime_config=/usr/share/nginx/html/runtime-config.js
 
+# Resolve a JSON Schema "type" keyword to a single type name. The keyword may be
+# a string ("array") or an array of strings (["array", "null"]); take the first.
+schema_type() {
+    # $1 = jq path expression pointing at the "type" keyword
+    printf '%s\n' "$config_schema" | jq -r "$1 | if type == \"array\" then .[0] else . end"
+}
+
 # Iterate over environment variables with "SB_" prefix
 env -0 | tr '\0' '\n' | cut -f1 -d= | grep "^SB_" | {
     echo "window.STAC_BROWSER_CONFIG = {"
@@ -106,8 +113,8 @@ env -0 | tr '\0' '\n' | cut -f1 -d= | grep "^SB_" | {
         value="$(printenv "$name")"
 
         # Get the argument type from the schema
-        argtype="$(printf '%s\n' "$config_schema" | jq -r ".properties.$argname.type[0]")"
-        arraytype="$(printf '%s\n' "$config_schema" | jq -r ".properties.$argname.items.type[0]")"
+        argtype="$(schema_type ".properties.\"$argname\".type")"
+        arraytype="$(schema_type ".properties.\"$argname\".items.type")"
 
         # Encode key/value
         printf '  %s: ' "$argname"

--- a/tests/docker/run-tests.sh
+++ b/tests/docker/run-tests.sh
@@ -27,11 +27,13 @@ echo "── Testing runtime configuration ──"
 allowed_domains="example.com,quote's.test,back\\slash.test"
 catalog_title=$'Earth\'s \\ catalog\nSecond line'
 path_prefix="/browser/"
+footer_links='[{"label":"Docs","url":"https://example.com/docs"}]'
 container_id="$(
   docker run --detach --rm \
     --env "SB_allowedDomains=$allowed_domains" \
     --env "SB_catalogTitle=$catalog_title" \
     --env "SB_pathPrefix=$path_prefix" \
+    --env "SB_footerLinks=$footer_links" \
     "$DOCKER_IMAGE"
 )"
 
@@ -66,6 +68,9 @@ assert.equal(
   "Earth's \\ catalog\nSecond line",
 );
 assert.equal(window.STAC_BROWSER_CONFIG.pathPrefix, process.env.PATH_PREFIX);
+assert.deepEqual(window.STAC_BROWSER_CONFIG.footerLinks, [
+  { label: "Docs", url: "https://example.com/docs" },
+]);
 NODE
 
 nginx_conf="$(docker exec "$container_id" cat /etc/nginx/conf.d/default.conf)"

--- a/vite.config.js
+++ b/vite.config.js
@@ -24,11 +24,12 @@ const package_ = JSON.parse(
   readFileSync(new URL("./package.json", import.meta.url), "utf-8")
 );
 
+const isSchemaType = (schema, type) =>
+  Array.isArray(schema.type) ? schema.type.includes(type) : (schema.type === type);
+
 const optionsForType = (type) =>
   Object.entries(configSchema.properties)
-    .filter(
-      ([, schema]) => Array.isArray(schema.type) && schema.type.includes(type)
-    )
+    .filter(([, schema]) => isSchemaType(schema, type))
     .map(([key]) => key);
 
 const defaultConfigPath = fileURLToPath(new URL("./config.js", import.meta.url));


### PR DESCRIPTION

## Proposed Changes

The Docker entrypoint and Vite config now support both forms of the JSON Schema `type` keyword, fixing a `jq` error when setting `SB_footerLinks` via environment variables

Closes #995

## Checklist

- [x] Added [changelog entry](CHANGELOG.md)
- [x] Added translations for new or changed UI strings
- [x] Executed linter (`npm run lint`)
- [x] Added and executed tests (`npm test`)
