### PR TITLE
Add optional date-only temporal extents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- New config option `omitTimeForMidnight` to show date-only Collection temporal extents when all boundaries are midnight UTC
 - A "Back" button on pages with external content returns to the page in the catalog from which the external content was reached
 - The source popover indicates when the shown data is not part of the configured catalog
 - Widget `ExternalWarning`: Shows an information on the page of a catalog, collection or item that is not part of the configured catalog

--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ You need to provide a field `stac_browser` and then you can set any of the follo
 - `defaultThumbnailSize`
 - `displayGeoTiffByDefault`
 - `maxDisplayPixels`
+- `omitTimeForMidnight`
 - `preferredAssets`
 - `showThumbnailsAsAssets`
 

--- a/config.js
+++ b/config.js
@@ -45,6 +45,7 @@ export default {
   pathPrefix: "/",
   historyMode: "history",
   cardViewMode: "cards",
+  omitTimeForMidnight: false,
   showFavorites: true,
   defaultCollectionSort: "title",
   defaultItemSort: null,

--- a/config.schema.json
+++ b/config.schema.json
@@ -100,6 +100,9 @@
       "type": "string",
       "enum": ["list", "cards"]
     },
+    "omitTimeForMidnight": {
+      "type": "boolean"
+    },
     "showFavorites": {
       "type": "boolean"
     },

--- a/docs/options.md
+++ b/docs/options.md
@@ -87,6 +87,7 @@ The override order for the configuration is:
 - [User Interface](#user-interface)
   - [enforcedColorMode](#enforcedcolormode)
   - [cardViewMode](#cardviewmode)
+  - [omitTimeForMidnight](#omittimeformidnight)
   - [showFavorites](#showfavorites)
   - [showKeywordsInItemCards](#showkeywordsinitemcards)
   - [showKeywordsInCatalogCards](#showkeywordsincatalogcards)
@@ -610,6 +611,10 @@ This config option allows to enforce a specific color mode, either `light` (defa
 ### cardViewMode
 
 The default view mode for lists of catalogs, collections and items. Either `"list"` or `"cards"` (default).
+
+### omitTimeForMidnight
+
+Omits the time from collection temporal extents when all defined interval boundaries are exactly midnight UTC. Defaults to `false`.
 
 ### showFavorites
 

--- a/src/StacBrowser.vue
+++ b/src/StacBrowser.vue
@@ -369,6 +369,7 @@ export default defineComponent({
         'defaultThumbnailSize',
         'displayGeoTiffByDefault',
         'maxDisplayPixels',
+        'omitTimeForMidnight',
         'preferredAssets',
         'showThumbnailsAsAssets'
       ];

--- a/src/components/Catalog.vue
+++ b/src/components/Catalog.vue
@@ -35,6 +35,7 @@ import { STAC } from 'stac-js';
 import { formatTemporalExtent } from '@radiantearth/stac-fields/formatters';
 import { BCard, BCardBody, BCardFooter, BCardText, BCardTitle } from 'bootstrap-vue-next';
 import AuthImage from './AuthImage.vue';
+import { getTemporalExtentFormatOptions } from '../utils';
 
 export default {
   name: 'Catalog',
@@ -68,7 +69,7 @@ export default {
     }
   },
   computed: {
-    ...mapState(['showKeywordsInCatalogCards']),
+    ...mapState(['omitTimeForMidnight', 'showKeywordsInCatalogCards']),
     ...mapGetters(['getStac']),
     classes() {
       let classes = ['catalog-card'];
@@ -88,9 +89,9 @@ export default {
     },
     temporalExtent() {
       if (this.data?.isCollection && this.data.extent?.temporal?.interval.length > 0) {
-        let extent = this.data.extent.temporal.interval[0];
+        const extent = this.data.extent.temporal.interval[0];
         if (Array.isArray(extent) && (typeof extent[0] === 'string' || typeof extent[1] === 'string')) {
-          return this.formatTemporalExtent(this.data.extent.temporal.interval[0], true);
+          return this.formatTemporalExtent(extent, true, getTemporalExtentFormatOptions(extent, this.omitTimeForMidnight));
         }
       }
       return null;

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,6 +9,19 @@ export const commonFileNames = ['catalog', 'collection', 'item'];
 // If you add new routes that may include .../external/... in the path, update this regexp.
 export const externalBrowserPathRE = /^\/((search|validation|management\/[\w-]+)\/)?external\//;
 
+export function getTemporalExtentFormatOptions(extents, omitTimeForMidnight) {
+  const boundaries = Array.isArray(extents) ? extents.flat().filter(value => value !== null) : [];
+  const allBoundariesAreMidnight = boundaries.length > 0 && boundaries.every(value => {
+    const date = new Date(value);
+    return !Number.isNaN(date.getTime()) &&
+      date.getUTCHours() === 0 &&
+      date.getUTCMinutes() === 0 &&
+      date.getUTCSeconds() === 0 &&
+      date.getUTCMilliseconds() === 0;
+  });
+  return { shorten: omitTimeForMidnight && allBoundariesAreMidnight };
+}
+
 export class BrowserError extends Error {
   constructor(message) {
     super(message);

--- a/src/views/Catalog.vue
+++ b/src/views/Catalog.vue
@@ -80,7 +80,7 @@ import ReadMore from "../components/ReadMore.vue";
 import ShowAssetLinkMixin from '../components/ShowAssetLinkMixin';
 import StacFieldsMixin from '../components/StacFieldsMixin';
 import { formatLicense, formatTemporalExtents } from '@radiantearth/stac-fields/formatters';
-import Utils from '../utils';
+import Utils, { getTemporalExtentFormatOptions } from '../utils';
 import { hasText, isObject, size } from 'stac-js/src/utils.js';
 import { addSchemaToDocument, createCatalogSchema } from '../schema-org';
 import { ItemCollection } from 'stac-js';
@@ -182,20 +182,7 @@ export default defineComponent({
           // Remove union temporal extent in favor of more concrete extents
           extents = extents.slice(1);
         }
-        const hasNonMidnightExtent = extents
-          .flat()
-          .filter(value => value !== null)
-          .some(value => {
-            const date = new Date(value);
-            return Number.isNaN(date.getTime()) ||
-              date.getUTCHours() !== 0 ||
-              date.getUTCMinutes() !== 0 ||
-              date.getUTCSeconds() !== 0 ||
-              date.getUTCMilliseconds() !== 0;
-          });
-        return this.formatTemporalExtents(extents, null, {
-          shorten: this.omitTimeForMidnight && !hasNonMidnightExtent
-        });
+        return this.formatTemporalExtents(extents, null, getTemporalExtentFormatOptions(extents, this.omitTimeForMidnight));
       }
       return null;
     },

--- a/src/views/Catalog.vue
+++ b/src/views/Catalog.vue
@@ -124,7 +124,7 @@ export default defineComponent({
     };
   },
   computed: {
-    ...mapState(['data', 'apiCatalogPriority', 'apiItemsLink', 'apiItemsPagination', 'apiItemsNumberMatched', 'nextCollectionsLink', 'stateQueryParameters']),
+    ...mapState(['data', 'apiCatalogPriority', 'apiItemsLink', 'apiItemsPagination', 'apiItemsNumberMatched', 'nextCollectionsLink', 'omitTimeForMidnight', 'stateQueryParameters']),
     ...mapGetters(['catalogs', 'collectionLink', 'isApiChildrenLoading', 'isCollection', 'items', 'getApiItemsLoading', 'parentLink', 'rootLink']),
     ignoredMetadataFields() {
       return getIgnoredFields(this.data, 'CatalogLike');
@@ -182,7 +182,20 @@ export default defineComponent({
           // Remove union temporal extent in favor of more concrete extents
           extents = extents.slice(1);
         }
-        return this.formatTemporalExtents(extents);
+        const hasNonMidnightExtent = extents
+          .flat()
+          .filter(value => value !== null)
+          .some(value => {
+            const date = new Date(value);
+            return Number.isNaN(date.getTime()) ||
+              date.getUTCHours() !== 0 ||
+              date.getUTCMinutes() !== 0 ||
+              date.getUTCSeconds() !== 0 ||
+              date.getUTCMilliseconds() !== 0;
+          });
+        return this.formatTemporalExtents(extents, null, {
+          shorten: this.omitTimeForMidnight && !hasNonMidnightExtent
+        });
       }
       return null;
     },

--- a/tests/e2e/collection.spec.js
+++ b/tests/e2e/collection.spec.js
@@ -5,7 +5,7 @@
  * item listing, and detail controls.
  */
 import { test, expect } from './fixtures.js';
-import { clearClipboard, readClipboard, waitForBrowserReady } from './helpers.js';
+import { clearClipboard, configureBrowser, readClipboard, waitForBrowserReady } from './helpers.js';
 import StaticCatalog from '../fixtures/instances/static.js';
 import API from '../fixtures/instances/api.js';
 
@@ -71,6 +71,48 @@ test.describe('Collection Metadata', () => {
     // not just "bis jetzt" on its own.
     await expect(temporalValue).toContainText(year);
     await expect(temporalValue).toContainText('bis jetzt');
+  });
+
+  test('Catalog - optionally omits midnight from temporal extents', async ({ page, worker }) => {
+    const { catalog, collection } = createStaticCatalog();
+    await configureBrowser(page, { omitTimeForMidnight: true });
+    await catalog.createServer(worker);
+
+    await page.goto(collection.getBrowserPath());
+    await waitForBrowserReady(page);
+
+    const temporalValue = page.locator('section.metadata .row', { hasText: /temporal extent/i }).locator('.value');
+    await expect(temporalValue).toContainText('2020');
+    await expect(temporalValue).not.toContainText(/(?:12|0|00):00:00/);
+  });
+
+  test('Catalog - keeps midnight time by default', async ({ page, worker }) => {
+    const { catalog, collection } = createStaticCatalog();
+    await catalog.createServer(worker);
+
+    await page.goto(collection.getBrowserPath());
+    await waitForBrowserReady(page);
+
+    const temporalValue = page.locator('section.metadata .row', { hasText: /temporal extent/i }).locator('.value');
+    await expect(temporalValue).toContainText(/(?:12|0|00):00:00/);
+  });
+
+  test('Catalog - keeps meaningful times when midnight omission is enabled', async ({ page, worker }) => {
+    const { catalog, collection } = createStaticCatalog();
+    collection.setMetadata({
+      extent: {
+        spatial: collection.getMetadata().extent.spatial,
+        temporal: { interval: [['2020-01-01T12:34:56Z', null]] }
+      }
+    });
+    await configureBrowser(page, { omitTimeForMidnight: true });
+    await catalog.createServer(worker);
+
+    await page.goto(collection.getBrowserPath());
+    await waitForBrowserReady(page);
+
+    const temporalValue = page.locator('section.metadata .row', { hasText: /temporal extent/i }).locator('.value');
+    await expect(temporalValue).toContainText(/12:34:56/);
   });
 
   test('API - should load and display collection metadata', async ({ page, worker }) => {

--- a/tests/e2e/collection.spec.js
+++ b/tests/e2e/collection.spec.js
@@ -115,6 +115,46 @@ test.describe('Collection Metadata', () => {
     await expect(temporalValue).toContainText(/12:34:56/);
   });
 
+  test('Catalog card - optionally omits midnight from temporal extents', async ({ page, worker }) => {
+    const { catalog } = createStaticCatalog();
+    await configureBrowser(page, { omitTimeForMidnight: true });
+    await catalog.createServer(worker);
+
+    await page.goto(catalog.root.getBrowserPath());
+    await waitForBrowserReady(page);
+
+    const temporalValue = page.locator('.catalog-card .datetime');
+    await expect(temporalValue).toContainText('2020');
+    await expect(temporalValue).not.toContainText(/(?:12|0|00):00:00/);
+  });
+
+  test('Catalog card - keeps midnight time by default', async ({ page, worker }) => {
+    const { catalog } = createStaticCatalog();
+    await catalog.createServer(worker);
+
+    await page.goto(catalog.root.getBrowserPath());
+    await waitForBrowserReady(page);
+
+    await expect(page.locator('.catalog-card .datetime')).toContainText(/(?:12|0|00):00:00/);
+  });
+
+  test('Catalog card - keeps meaningful times when midnight omission is enabled', async ({ page, worker }) => {
+    const { catalog, collection } = createStaticCatalog();
+    collection.setMetadata({
+      extent: {
+        spatial: collection.getMetadata().extent.spatial,
+        temporal: { interval: [['2020-01-01T12:34:56Z', null]] }
+      }
+    });
+    await configureBrowser(page, { omitTimeForMidnight: true });
+    await catalog.createServer(worker);
+
+    await page.goto(catalog.root.getBrowserPath());
+    await waitForBrowserReady(page);
+
+    await expect(page.locator('.catalog-card .datetime')).toContainText(/12:34:56/);
+  });
+
   test('API - should load and display collection metadata', async ({ page, worker }) => {
     const { api, collection } = createAPI();
     


### PR DESCRIPTION
## Proposed Changes

- Add an opt-in `omitTimeForMidnight` setting for collection temporal extents.
- Render date-only values when every defined interval boundary is midnight UTC.
- Preserve the existing default and retain full timestamps for meaningful non-midnight times.
- Document the option and allow root-catalog configuration.

Closes #453.

OpenAI Codex assisted with implementation and test coverage; the changes were reviewed and verified locally.

## Validation

- `npm run lint`
- `npm run docs:lint`
- `npx eslint tests/e2e/collection.spec.js`
- `npm run build`
- `npx playwright test tests/e2e/collection.spec.js` - 21 passed

## Checklist

- [ ] Added [changelog entry](CHANGELOG.md)
- [x] No translations are required because no UI strings changed
- [x] Executed linter (`npm run lint`)
- [x] Added and executed targeted tests