### PR TITLE
Respect display options for child maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New config option `displayPreviewsForChildren` controls preview images on maps showing multiple Items
+
 ## [5.1.0] - 2026-09-07
 
 ### Added

--- a/config.js
+++ b/config.js
@@ -37,6 +37,7 @@ export default {
   displayGeoTiffByDefault: false,
   displayPreview: true,
   displayOverview: true,
+  displayPreviewsForChildren: true,
   displayOverviewsForChildren: false,
   maxDisplayPixels: null,
   buildTileUrlTemplate: null,

--- a/config.schema.json
+++ b/config.schema.json
@@ -63,6 +63,9 @@
     "displayOverview": {
       "type": "boolean"
     },
+    "displayPreviewsForChildren": {
+      "type": "boolean"
+    },
     "displayOverviewsForChildren": {
       "type": "boolean"
     },

--- a/docs/options.md
+++ b/docs/options.md
@@ -78,6 +78,7 @@ The override order for the configuration is:
   - [useTileLayerAsFallback](#usetilelayerasfallback)
   - [displayPreview](#displaypreview)
   - [displayOverview](#displayoverview)
+  - [displayPreviewsForChildren](#displaypreviewsforchildren)
   - [displayOverviewsForChildren](#displayoverviewsforchildren)
   - [displayGeoTiffByDefault](#displaygeotiffbydefault)
   - [maxDisplayPixels](#maxdisplaypixels)
@@ -490,6 +491,10 @@ If both `displayPreview` and `displayOverview` (see below) are enabled, STAC Bro
 ### displayOverview
 
 If set to `true` (default), allows to display COGs and, if `displayGeoTiffByDefault` is enabled, GeoTiffs on the map as default visualization, usually from an asset with role `overview` or `visual`.
+
+### displayPreviewsForChildren
+
+Similar to `displayPreview` (see above), but applies only to maps that show multiple STAC entities, i.e. lists of items for a Collection or Search. Defaults to `true`.
 
 ### displayOverviewsForChildren
 

--- a/src/components/MapView.vue
+++ b/src/components/MapView.vue
@@ -92,7 +92,7 @@ export default {
     };
   },
   computed: {
-    ...mapState(['displayOverviewsForChildren']),
+    ...mapState(['displayPreviewsForChildren', 'displayOverviewsForChildren']),
     container() {
       if (this.isFullScreen) {
         return '#' + this.mapId;
@@ -104,7 +104,7 @@ export default {
     childrenOptions() {
       const showItems = this.children && this.children.isItemCollection;
       return {
-        displayPreview: showItems,
+        displayPreview: showItems && this.displayPreviewsForChildren,
         displayOverview: showItems && this.displayOverviewsForChildren
       };
     },

--- a/tests/e2e/mapping.spec.js
+++ b/tests/e2e/mapping.spec.js
@@ -12,6 +12,50 @@
 import { test, expect } from './fixtures.js';
 import { waitForBrowserReady, waitForMapReady, getMapState } from './helpers.js';
 import StaticCatalog from '../fixtures/instances/static.js';
+import API from '../fixtures/instances/api.js';
+
+function getChildMapOptions(page) {
+  return page.evaluate(() => {
+    let el = document.querySelector('.map-container .map');
+    while (el) {
+      const inst = el.__vueParentComponent;
+      try {
+        const options = inst?.proxy?.childrenOptions ?? inst?.ctx?.childrenOptions;
+        if (options) {
+          return options;
+        }
+      } catch {
+        // Continue walking up the component tree.
+      }
+      el = el.parentElement;
+    }
+    return null;
+  });
+}
+
+test.describe('Child map display options', () => {
+  test('can configure previews and overviews independently', async ({ page, worker }) => {
+    const api = API.minimalApi();
+    const collection = api.addCollection('collection');
+    api.addManyItems(collection, 2);
+    await api.createServer(worker);
+
+    await page.addInitScript(() => {
+      window.STAC_BROWSER_CONFIG = {
+        displayPreviewsForChildren: false,
+        displayOverviewsForChildren: true,
+      };
+    });
+    await page.goto(collection.getBrowserPath());
+    await waitForBrowserReady(page);
+    await waitForMapReady(page);
+
+    await expect.poll(() => getChildMapOptions(page)).toEqual({
+      displayPreview: false,
+      displayOverview: true,
+    });
+  });
+});
 
 /**
  * Build a static catalog containing a single Item near New Zealand whose


### PR DESCRIPTION
## Proposed Changes

`displayPreview` and `displayOverview` options should propagate to `childrenOptions`.

Tried to remove thumbnails and overviews in search results (within a Collection and in global search)

## Checklist

- [x] Added [changelog entry](CHANGELOG.md)
- [ ] Added translations for new or changed UI strings
- [x] Executed linter (`npm run lint`)
- [x] Added and executed tests (`npm test`)
