### PR TITLE
Update Contributing file npm install reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ so you need a recent version of [NodeJS and npm](https://nodejs.org/en/) install
 You can run the following commands (see also "[Get started](README.md#get-started)" in the README):
 
 - Getting Started
-  - `npm run install`: Install the dependencies, this is required once at the beginning.
+  - `npm install`: Install the dependencies, this is required once at the beginning.
   - `npm start`: Start the development server
 - Linting
   - `npm run lint`: Lint the source code files


### PR DESCRIPTION
## Proposed Changes

Update [CONTRIBUTING.md](https://github.com/radiantearth/stac-browser/blob/main/CONTRIBUTING.md) to use `npm install` vs `npm run install`. 

Addresses: https://github.com/radiantearth/stac-browser/issues/1007

## Checklist

- [ ] Added [changelog entry](CHANGELOG.md) (seems too minor for this)
- [ ] Added translations for new or changed UI strings (not a user facing string change)
- [ ] Executed linter (`npm run lint`) (ran, no changes)
- [ ] Added and executed tests (`npm test`) (not testable, documentation only)
