### PR TITLE
Rewrite how maps handle focus and certain interactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Show favorite button in the search cards by default
+- Maps don't trap page scrolling: scroll-wheel zoom and one-finger panning require a click/tap on the map first, indicated by a hint and a highlight
 
 ### Fixed
 
@@ -25,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The conformance classes of the configured catalog are no longer applied to external content,
   e.g. sorting and filtering are no longer offered for (and sent to) external APIs that may not support them
 - The map renders very small footprints instead of staying empty
-- Maps on item pages react to drag and mouse-wheel interactions again without requiring the map to be focused first
+- Maps can be panned and zoomed with the keyboard after focusing them
 
 ## [5.1.0-rc.1] - 2026-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The conformance classes of the configured catalog are no longer applied to external content,
   e.g. sorting and filtering are no longer offered for (and sent to) external APIs that may not support them
 - The map renders very small footprints instead of staying empty
-- Maps on item pages react to mouse and keyboard interactions again without requiring to focus the map first
+- Maps on item pages react to drag and mouse-wheel interactions again without requiring the map to be focused first
 
 ## [5.1.0-rc.1] - 2026-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The conformance classes of the configured catalog are no longer applied to external content,
   e.g. sorting and filtering are no longer offered for (and sent to) external APIs that may not support them
 - The map renders very small footprints instead of staying empty
+- Maps on item pages react to mouse and keyboard interactions again without requiring to focus the map first
 
 ## [5.1.0-rc.1] - 2026-08-15
 

--- a/src/components/MapView.vue
+++ b/src/components/MapView.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="map-container">
-    <div ref="map" class="map" :id="mapId" tabindex="0">
+    <div ref="map" class="map" :id="mapId" tabindex="0" role="region" :aria-label="$t('map')">
       <!-- this will be filled by OpenLayers -->
       <LayerControl :map="map" :maxZoom="maxZoom" />
       <TextControl v-if="empty" :map="map" :text="$t('mapping.nodata')" />

--- a/src/components/MapView.vue
+++ b/src/components/MapView.vue
@@ -1,10 +1,11 @@
 <template>
   <div class="map-container">
-    <div ref="map" class="map" :id="mapId">
+    <div ref="map" class="map" :id="mapId" tabindex="0">
       <!-- this will be filled by OpenLayers -->
       <LayerControl :map="map" :maxZoom="maxZoom" />
       <TextControl v-if="empty" :map="map" :text="$t('mapping.nodata')" />
       <TextControl v-else-if="!hasBasemap" :map="map" :text="$t('mapping.nobasemap')" />
+      <div class="focus-hint" :class="{visible: focusHint}">{{ $t('mapping.focusHint') }}</div>
     </div>
     <ConfirmModal
       v-model="showDisplayLimitModal" :title="$t('mapping.displayLimit.title')"
@@ -73,10 +74,6 @@ export default {
       type: Object,
       default: null
     },
-    onfocusOnly: {
-      type: Boolean,
-      default: false
-    },
     popover: {
       type: Boolean,
       default: false
@@ -91,6 +88,7 @@ export default {
       selector: null,
       mapId: `map-${++mapId}`,
       displayLimitError: null,
+      focusHint: false,
     };
   },
   computed: {
@@ -172,9 +170,17 @@ export default {
     // These are created here and not in data() to avoid them being reactive
     this.stacLayer = null;
     this.ignoreDisplayLimit = false;
+    this.focusHintTimer = null;
   },
   async mounted() {
+    // Explain that the map must be focused before it reacts to scroll zoom and touch panning
+    this.$refs.map.addEventListener('wheel', this.onGatedInteraction, { passive: true });
+    this.$refs.map.addEventListener('touchmove', this.onGatedInteraction, { passive: true });
+    this.$refs.map.addEventListener('focusin', this.hideFocusHint);
     await this.showStacLayer();
+  },
+  beforeUnmount() {
+    clearTimeout(this.focusHintTimer);
   },
   methods: {
     async showStacLayer() {
@@ -183,7 +189,8 @@ export default {
       this.displayLimitError = null;
       this.ignoreDisplayLimit = false;
 
-      await this.createMap(this.$refs.map, this.onfocusOnly);
+      // Only interact with a focused map to avoid trapping page scrolling
+      await this.createMap(this.$refs.map, true);
 
       if (this.stac) {
         this.addStacLayer();
@@ -293,6 +300,18 @@ export default {
     resetSelection() {
       this.selection = null;
     },
+    onGatedInteraction() {
+      if (this.$refs.map.contains(document.activeElement)) {
+        return;
+      }
+      this.focusHint = true;
+      clearTimeout(this.focusHintTimer);
+      this.focusHintTimer = setTimeout(() => this.focusHint = false, 2000);
+    },
+    hideFocusHint() {
+      clearTimeout(this.focusHintTimer);
+      this.focusHint = false;
+    },
     showAnyway() {
       this.displayLimitError = null;
       this.ignoreDisplayLimit = true;
@@ -318,6 +337,26 @@ export default {
 #stac-browser {
   .map-popover {
     max-width: 400px;
+  }
+
+  .map > .focus-hint {
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 1rem;
+    background-color: rgba(0, 0, 0, 0.4);
+    color: #fff;
+    opacity: 0;
+    transition: opacity 0.3s;
+    pointer-events: none;
+
+    &.visible {
+      opacity: 1;
+    }
   }
 
   .popover-target {

--- a/src/components/MapView.vue
+++ b/src/components/MapView.vue
@@ -183,7 +183,7 @@ export default {
       this.displayLimitError = null;
       this.ignoreDisplayLimit = false;
 
-      await this.createMap(this.$refs.map, this.stac, this.onfocusOnly);
+      await this.createMap(this.$refs.map, this.onfocusOnly);
 
       if (this.stac) {
         this.addStacLayer();

--- a/src/components/maps/MapMixin.js
+++ b/src/components/maps/MapMixin.js
@@ -5,7 +5,10 @@ import { mapGetters, mapState } from 'vuex';
 import { needsAuthenticatedFetch } from '../../models/authMedia';
 import OlMap from 'ol/Map.js';
 import View from 'ol/View.js';
+import Kinetic from 'ol/Kinetic.js';
 import { defaults } from 'ol/interaction/defaults';
+import DragPan from 'ol/interaction/DragPan.js';
+import { all, focus, noModifierKeys, primaryAction } from 'ol/events/condition.js';
 import ZoomControl from 'ol/control/Zoom.js';
 import AttributionControl from 'ol/control/Attribution.js';
 import FullScreenControl from 'ol/control/FullScreen.js';
@@ -87,7 +90,7 @@ export default {
       }
       return null;
     },
-    async createMap(element, onfocusOnly = false) {
+    async createMap(element, onFocusOnly = false) {
       let projection = 'EPSG:3857';
       let visibleLayer = 0;
 
@@ -104,15 +107,28 @@ export default {
         }
       }
 
+      const interactions = defaults({
+        altShiftDragRotate: false,
+        pinchRotate: false,
+        dragPan: !onFocusOnly,
+        onFocusOnly
+      });
+      if (onFocusOnly) {
+        // Starting a mouse drag on the map is already a clear intent to pan,
+        // but a one-finger touch drag is how the page is scrolled,
+        // so only the latter requires the map to be focused first
+        interactions.push(new DragPan({
+          condition: (event) => all(noModifierKeys, primaryAction)(event)
+            && (event.originalEvent.pointerType !== 'touch' || focus(event)),
+          kinetic: new Kinetic(-0.005, 0.05, 100)
+        }));
+      }
+
       // Create map instance
       this.map = markRaw(new OlMap({
         target: element,
         controls: [],
-        interactions: defaults({
-          altShiftDragRotate: false,
-          pinchRotate: false,
-          onfocusOnly
-        }),
+        interactions,
         view: new View({
           center: [0, 0],
           zoom: 0,

--- a/src/components/maps/MapSelect.vue
+++ b/src/components/maps/MapSelect.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="map-container">
-    <div ref="map" class="map">
+    <div ref="map" class="map" tabindex="0">
       <!-- this will be filled by OpenLayers -->
       <TextControl :text="help" :map="map" />
       <UserLocationControl :map="map" :maxZoom="maxZoom" />
@@ -160,7 +160,9 @@ export default {
     async initMap() {
       this.map = null;
 
-      await this.createMap(this.$refs.map, true);
+      // The map is only shown after opting in via a checkbox,
+      // so interactions are enabled without requiring focus
+      await this.createMap(this.$refs.map);
 
       // Add extent interaction for bbox selection
       const condition = (event) => {

--- a/src/components/maps/MapSelect.vue
+++ b/src/components/maps/MapSelect.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="map-container">
-    <div ref="map" class="map" tabindex="0">
+    <div ref="map" class="map" tabindex="0" role="region" :aria-label="$t('map')">
       <!-- this will be filled by OpenLayers -->
       <TextControl :text="help" :map="map" />
       <UserLocationControl :map="map" :maxZoom="maxZoom" />

--- a/src/components/maps/MapSelect.vue
+++ b/src/components/maps/MapSelect.vue
@@ -160,7 +160,7 @@ export default {
     async initMap() {
       this.map = null;
 
-      await this.createMap(this.$refs.map, this.stac, true);
+      await this.createMap(this.$refs.map, true);
 
       // Add extent interaction for bbox selection
       const condition = (event) => {

--- a/src/locales/de/texts.json
+++ b/src/locales/de/texts.json
@@ -237,6 +237,7 @@
       "title": "Großer Datensatz"
     },
     "fit": "Ansicht an räumliche Ausdehnung anpassen",
+    "focusHint": "Karte anklicken oder antippen, um zu zoomen und zu verschieben",
     "layers": {
       "base": "Grundkarten",
       "footprint": "Räumliche Ausdehnung",

--- a/src/locales/en/texts.json
+++ b/src/locales/en/texts.json
@@ -237,6 +237,7 @@
       "title": "Large dataset"
     },
     "fit": "Fit to extent",
+    "focusHint": "Click or tap the map to zoom and pan",
     "layers": {
       "base": "Base Layers",
       "footprint": "Footprint",

--- a/src/theme/page.scss
+++ b/src/theme/page.scss
@@ -282,6 +282,25 @@ svg {
     overflow: hidden;
     position: relative;
     z-index: 0;
+
+    // Indicate that the map reacts to scroll and drag interactions,
+    // matching the focus style of form inputs.
+    &:focus-within {
+      border-radius: var(--bs-border-radius);
+      box-shadow: 0 0 0 0.25rem rgba(var(--bs-primary-rgb), 0.25);
+
+      // The border is drawn via ::after as it would otherwise
+      // be hidden behind the map canvas
+      &::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        z-index: 1;
+        pointer-events: none;
+        border: var(--bs-border-width) var(--bs-border-style) #{$input-focus-border-color};
+        border-radius: var(--bs-border-radius);
+      }
+    }
   }
 
   h2 {

--- a/src/views/ApiSearch.vue
+++ b/src/views/ApiSearch.vue
@@ -35,7 +35,7 @@
         <template v-else>
           <WidgetHook id="view-search-results-start" />
           <div id="search-map" v-if="data">
-            <MapView :stac="parent" :children="data" onfocusOnly popover />
+            <MapView :stac="parent" :children="data" popover />
           </div>
           <Catalogs
             v-if="isCollectionSearch" :catalogs="results" collectionsOnly

--- a/src/views/Catalog.vue
+++ b/src/views/Catalog.vue
@@ -28,7 +28,7 @@
           <b-card no-body class="maps-preview">
             <b-tabs v-model="tab" pills card vertical end>
               <b-tab v-if="isCollection" :id="tabIds.map" :title="$t('map')" no-body>
-                <MapView :stac="data" v-bind="mapData" @changed="dataChanged" @empty="handleEmptyMap" onfocusOnly popover />
+                <MapView :stac="data" v-bind="mapData" @changed="dataChanged" @empty="handleEmptyMap" popover />
               </b-tab>
               <b-tab v-if="hasThumbnails" :id="tabIds.thumbnails" :title="$t('thumbnails')" no-body>
                 <Thumbnails :thumbnails="thumbnails" />


### PR DESCRIPTION
## Proposed Changes

- Fix stray `createMap` argument that unintentionally passed the STAC object as `onfocusOnly` (#1012 original fix)
- Fix `onFocusOnly` casing — the lowercase key was silently ignored by OpenLayers, so focus gating never actually worked
- Add `tabindex="0"` to map elements — required for OL focus gating, also enables keyboard pan/zoom
- Enable focus gating for all `MapView` maps (item, catalog, search); removed the now-pointless `onfocusOnly` prop
- Exempt the bbox picker (`MapSelect`) — it's behind the "Filter by spatial extent" checkbox, intent is already clear
- Gate only what conflicts with page scrolling: wheel zoom and one-finger touch pan need focus; mouse drag, double-click zoom and pinch work immediately
- Show a hint overlay ("Click or tap the map to zoom and pan") when scrolling/swiping over an unfocused map (en + de translations)
- Highlight focused maps with the same focus style as form inputs (outward ring + tinted border, drawn via `::after`/box-shadow since an outline is hidden behind the canvas)
- Changelog entries for the new behavior and the keyboard support

## Checklist

- [x] Added [changelog entry](CHANGELOG.md)
- [x] Added translations for new or changed UI strings
- [x] Executed linter (`npm run lint`)
- [x] Added and executed tests (`npm test`)
